### PR TITLE
LRCI-7325 Add whitelist property to force SF build from source

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -10417,6 +10417,7 @@ tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/
 					<or>
 						<contains string="${git.diff}" substring="modules${file.separator}util${file.separator}source-formatter" />
 						<contains string="${git.diff}" substring="source-formatter.properties" />
+						<contains string=",${source.formatter.force.build.from.source.test.suites}," substring=",${env.CI_TEST_SUITE}," />
 						<matches pattern="release-((\d{4})\.q([1-4])|(7\.[0-4]\.[0-9]?[0-9]\.\d+))" string="${liferay.portal.branch}" />
 					</or>
 					<then>

--- a/test.properties
+++ b/test.properties
@@ -6907,6 +6907,8 @@
     # Source Formatter
     #
 
+    source.formatter.force.build.from.source.test.suites=sf
+
     test.batch.dist.app.servers[sf]=
     test.batch.names[sf]=source-format-current-branch
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7325

**What is being fixed:** The `source-format-current-branch` target only builds the Source Formatter jar from HEAD when the diff touches `modules/util/source-formatter` or `source-formatter.properties`, or when running on a release branch. This means that a freshly merged SF change upstream is not exercised by `ci:test:sf` runs until BChan publishes a new jar — contributors have resorted to adding dummy edits to force the build-from-source path.

**How it is being fixed:** A new property, `source.formatter.force.build.from.source.test.suites`, holds a comma-separated whitelist of `CI_TEST_SUITE` names. When the current suite is in that list, `source-format-current-branch` builds SF from source regardless of the diff. The default whitelist contains `sf`, so `ci:test:sf` always exercises the latest SF code from HEAD. Other suites remain opt-in.