### PR TITLE
LRCI-6191 Add whitelist property to force SF build from source for specific test suites

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -10417,6 +10417,7 @@ tar --extract --file=liferay-portal-source.tar.gz modules/core/portal-bootstrap/
 					<or>
 						<contains string="${git.diff}" substring="modules${file.separator}util${file.separator}source-formatter" />
 						<contains string="${git.diff}" substring="source-formatter.properties" />
+						<contains string="${sf.force.build.from.source.suites}" substring="${env.CI_TEST_SUITE}" />
 						<matches pattern="release-((\d{4})\.q([1-4])|(7\.[0-4]\.[0-9]?[0-9]\.\d+))" string="${liferay.portal.branch}" />
 					</or>
 					<then>

--- a/test.properties
+++ b/test.properties
@@ -6907,6 +6907,8 @@
     # Source Formatter
     #
 
+    sf.force.build.from.source.suites=sf
+
     test.batch.dist.app.servers[sf]=
     test.batch.names[sf]=source-format-current-branch
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-6191

**What is being fixed:** The `source-format-current-branch` target only builds the Source Formatter jar from HEAD when the diff touches `modules/util/source-formatter` or `source-formatter.properties`, or when on a release branch. Freshly merged SF changes upstream are not exercised until BChan publishes a new jar — contributors have had to add dummy edits to force the source-build path.

**How it is being fixed:** A new property, `sf.force.build.from.source.suites`, holds a whitelist of `CI_TEST_SUITE` names. When the current suite is in that list, `source-format-current-branch` builds SF from source regardless of the diff. The default whitelist contains `sf`, so `ci:test:sf` always exercises the latest SF code from HEAD. Other suites remain opt-in by adding to the list.