### PR TITLE
LRCI-6857 Fix case-insensitive check for git repository error in buildFinished hook

### DIFF
--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -60,7 +60,9 @@ gradle.buildFinished {
 
 	String errorString = errorByteArrayOutputStream.toString()
 
-	if (!errorString.toLowerCase().contains("not a git repository")) {
+	String lowerCaseErrorString = errorString.toLowerCase()
+
+	if (!lowerCaseErrorString.contains("not a git repository")) {
 		logger.error errorString
 	}
 

--- a/modules/init.gradle
+++ b/modules/init.gradle
@@ -60,7 +60,7 @@ gradle.buildFinished {
 
 	String errorString = errorByteArrayOutputStream.toString()
 
-	if (!errorString.contains("Not a git repository")) {
+	if (!errorString.toLowerCase().contains("not a git repository")) {
 		logger.error errorString
 	}
 


### PR DESCRIPTION
## Summary
- `modules/init.gradle` has a `buildFinished` hook that calls `git ls-files` to find untracked `.pom` files in the Gradle user home directory
- When running on AWS (where directories are extracted from git archives with no `.git`), git outputs: `fatal: not a git repository (or any of the parent directories): .git`
- The existing suppression check `errorString.contains("Not a git repository")` never matches because git emits lowercase `"not a git repository"`
- Fix: use `errorString.toLowerCase().contains("not a git repository")` to make the check case-insensitive

## Root cause
Case sensitivity bug — the check was written with capital "N" but git's error message uses lowercase "n". Build passes regardless (due to `ignoreExitValue = true`) but the error floods CI logs and causes confusion.

https://liferay.atlassian.net/browse/LRCI-6674

🤖 Generated with [Claude Code](https://claude.com/claude-code)