### PR TITLE
LPD-86832 Test fix for SF NoSuchFileException on .gradle/

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -51,6 +51,8 @@
 				tofile="${local.cache.artifact}"
 			/>
 
+			<mkdir dir="${project.dir}/.gradle" />
+
 			<propertyfile file="${project.dir}/.gradle/gradle.properties">
 				<entry key="@{artifact.name}.version" value="@{artifact.version}" />
 			</propertyfile>

--- a/build-test.xml
+++ b/build-test.xml
@@ -2485,6 +2485,8 @@ war.path=${app.server.portal.dir}/</echo>
 		<attribute name="task" />
 
 		<sequential>
+			<mkdir dir="${project.dir}/.gradle" />
+
 			<propertyfile file="${project.dir}/.gradle/gradle.properties">
 				<entry key="sdk.dir" value="${sdk.dir}" />
 			</propertyfile>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -85,6 +85,14 @@ definition {
 	macro gotoPortlet(site = null, portlet = null, category = null) {
 		if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
 			ApplicationsMenu.gotoSite(site = ${site});
+
+			if (isSet(site)) {
+				var siteNameURL = StringUtil.replace(${site}, " ", "-");
+
+				var siteNameURL = StringUtil.lowerCase(${siteNameURL});
+
+				Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
+			}
 		}
 
 		ProductMenuHelper.openProductMenu();

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
@@ -57,7 +57,7 @@
 </tr>
 <tr>
 	<td>VIEW_ALL_LINK</td>
-	<td>//ul[@role='menu' and contains(@class, 'sites-list')]//button[@role='menuitem' and contains(.,'View All')]</td>
+	<td>//ul[@role='menu' and contains(@class, 'sites-list')]//*[@role='menuitem' and contains(.,'View All')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary

- Adds `<mkdir dir="${project.dir}/.gradle" />` before the two `<propertyfile file="${project.dir}/.gradle/gradle.properties">` calls in `build-test.xml` (the `poshi-execute` macrodef) and `build-test-batch.xml` (the `store-version` macrodef). `<propertyfile>` does not auto-create parent directories, so it fails with `java.nio.file.NoSuchFileException` whenever the `.gradle/` directory isn't already present.
- In `test-portal-source-format` jobs nothing in the flow runs Gradle before `<poshi-execute>` is called from `run-poshi-validation`, so `.gradle/` does not yet exist and the job blows up the moment `poshi.files.modified=true`. The original failure on PR #3562's `ci:test:sf` run was:
  ```
  /opt/dev/projects/github/liferay-portal/build-test.xml:2488: java.nio.file.NoSuchFileException: /opt/dev/projects/github/liferay-portal/.gradle/gradle.properties
  ```
- Branch is cut directly off `javalosjr96:LPD-86832_rebased` (head of upstream PR liferay-database-infra/liferay-portal#3562) so the same `ci:test:sf` job that hit the bug can be re-run on this PR with the fix in place.

## Test plan

- [ ] Re-run `ci:test:sf` against this PR
- [ ] Confirm `run-poshi-validation` no longer fails at `build-test.xml:2488`
- [ ] Confirm the rest of the source-format flow still completes