### PR TITLE
LRCI-6894 Dummy change to trigger workspace bundle init CI test

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRef.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitRef.java
@@ -10,6 +10,8 @@ package com.liferay.jenkins.results.parser;
  */
 public interface GitRef {
 
+	// LRCI-7163-4 dummy change to trigger workspace bundle init CI test
+
 	public String getName();
 
 	public String getSHA();


### PR DESCRIPTION
Dummy PR to trigger the PR tester against the workspace bundle init flow. Successor to #523/#527. Used to exercise the LRCI-7665 Playwright-on-Compose batch flow.