### PR TITLE
LRCI-7942 Stop round tripping invocation parameters through a decoded URL

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -3099,13 +3099,15 @@ public abstract class BaseBuild implements Build {
 				continue;
 			}
 
-			String[] nameValueArray = parameter.split("=");
+			String[] nameValueArray = parameter.split("=", 2);
+
+			String name = _decodeParameter(nameValueArray[0]);
 
 			if (nameValueArray.length == 2) {
-				_parameters.put(nameValueArray[0], nameValueArray[1]);
+				_parameters.put(name, _decodeParameter(nameValueArray[1]));
 			}
-			else if (nameValueArray.length == 1) {
-				_parameters.put(nameValueArray[0], "");
+			else {
+				_parameters.put(name, "");
 			}
 		}
 	}
@@ -3317,6 +3319,18 @@ public abstract class BaseBuild implements Build {
 
 	private void _archiveTestReportJSON() {
 		_archive(null, false, "testReport/api/json");
+	}
+
+	private String _decodeParameter(String parameter) {
+		try {
+			return JenkinsResultsParserUtil.decode(parameter);
+		}
+		catch (Exception exception) {
+			System.out.println(
+				"Unable to decode the query string parameter " + parameter);
+
+			return parameter;
+		}
 	}
 
 	private int _getMaximumInvocationCount() {
@@ -3643,15 +3657,6 @@ public abstract class BaseBuild implements Build {
 			return;
 		}
 
-		try {
-			invocationURL = JenkinsResultsParserUtil.decode(invocationURL);
-		}
-		catch (UnsupportedEncodingException unsupportedEncodingException) {
-			throw new IllegalArgumentException(
-				"Unable to decode " + invocationURL,
-				unsupportedEncodingException);
-		}
-
 		Matcher invocationURLMatcher = _invocationURLPattern.matcher(
 			invocationURL);
 
@@ -3659,7 +3664,7 @@ public abstract class BaseBuild implements Build {
 			throw new RuntimeException("Invalid invocation URL");
 		}
 
-		setJobName(invocationURLMatcher.group("jobName"));
+		setJobName(_decodeParameter(invocationURLMatcher.group("jobName")));
 
 		JenkinsCohort jenkinsCohort = JenkinsCohort.getInstance(
 			invocationURLMatcher.group("cohortName"));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseParentBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseParentBuild.java
@@ -8,7 +8,6 @@ package com.liferay.jenkins.results.parser;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -72,14 +71,7 @@ public abstract class BaseParentBuild extends BaseBuild implements ParentBuild {
 		for (Map.Entry<String, String> urlEntry : urlAxisNames.entrySet()) {
 			String url = urlEntry.getKey();
 
-			try {
-				url = JenkinsResultsParserUtil.getLocalURL(
-					JenkinsResultsParserUtil.decode(url));
-			}
-			catch (UnsupportedEncodingException unsupportedEncodingException) {
-				throw new IllegalArgumentException(
-					"Unable to decode " + url, unsupportedEncodingException);
-			}
+			url = JenkinsResultsParserUtil.getLocalURL(url);
 
 			if (!hasBuildURL(url)) {
 				final String axisName = urlEntry.getValue();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -510,6 +510,17 @@ public class JenkinsResultsParserUtil {
 		return new URL(uriASCIIString.replace("#", "%23"));
 	}
 
+	public static String encodeURLParameter(String string) {
+		try {
+			string = URLEncoder.encode(string, StandardCharsets.UTF_8.name());
+
+			return string.replace("+", "%20");
+		}
+		catch (UnsupportedEncodingException unsupportedEncodingException) {
+			throw new RuntimeException(unsupportedEncodingException);
+		}
+	}
+
 	public static String escapeForBash(String string) {
 		string = string.replaceAll(" ", "\\\\ ");
 		string = string.replaceAll("'", "\\\\\\\'");

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -8,7 +8,9 @@ package com.liferay.jenkins.results.parser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -64,6 +66,63 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertEquals(
 			Arrays.asList(firstBuildURL), baseBuild.getBadBuildURLs());
+	}
+
+	@Test
+	public void testLoadParametersFromQueryString() {
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuild, "_parameters", new HashMap<String, String>());
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).loadParametersFromQueryString(
+			Mockito.anyString()
+		);
+
+		baseBuild.loadParametersFromQueryString(
+			JenkinsResultsParserUtil.combine(
+				"token=abc123&PORTAL_BATCH_TEST_SELECTOR=PortalSmoke%23Smoke",
+				"&TESTRAY_PROJECT_NAME=AWS%20%26%20CI",
+				"&PORTAL_BUILD_NOTES=100%25%20pass&PORTAL_UPSTREAM=master",
+				"&AXIS_VARIABLE=&PORTAL_QUERY=a%3Db"));
+
+		Map<String, String> parameters = ReflectionTestUtil.getFieldValue(
+			baseBuild, "_parameters");
+
+		Assert.assertEquals(
+			"PortalSmoke#Smoke", parameters.get("PORTAL_BATCH_TEST_SELECTOR"));
+		Assert.assertEquals("AWS & CI", parameters.get("TESTRAY_PROJECT_NAME"));
+		Assert.assertEquals("100% pass", parameters.get("PORTAL_BUILD_NOTES"));
+		Assert.assertEquals("master", parameters.get("PORTAL_UPSTREAM"));
+		Assert.assertEquals("", parameters.get("AXIS_VARIABLE"));
+		Assert.assertEquals("a=b", parameters.get("PORTAL_QUERY"));
+	}
+
+	@Test
+	public void testLoadParametersFromQueryStringIllegalEscape() {
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuild, "_parameters", new HashMap<String, String>());
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).loadParametersFromQueryString(
+			Mockito.anyString()
+		);
+
+		baseBuild.loadParametersFromQueryString(
+			"PORTAL_BUILD_NOTES=100% pass&PORTAL_UPSTREAM=master");
+
+		Map<String, String> parameters = ReflectionTestUtil.getFieldValue(
+			baseBuild, "_parameters");
+
+		Assert.assertEquals("100% pass", parameters.get("PORTAL_BUILD_NOTES"));
+		Assert.assertEquals("master", parameters.get("PORTAL_UPSTREAM"));
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -28,6 +28,22 @@ import org.mockito.Mockito;
 public class JenkinsResultsParserUtilTest
 	extends com.liferay.jenkins.results.parser.Test {
 
+	@Test
+	public void testEncodeURLParameter() {
+		testEquals(
+			"PortalSmoke%23Smoke",
+			JenkinsResultsParserUtil.encodeURLParameter("PortalSmoke#Smoke"));
+		testEquals(
+			"AWS%20CI", JenkinsResultsParserUtil.encodeURLParameter("AWS CI"));
+		testEquals("a%26b", JenkinsResultsParserUtil.encodeURLParameter("a&b"));
+		testEquals(
+			"100%25%20pass",
+			JenkinsResultsParserUtil.encodeURLParameter("100% pass"));
+		testEquals("a%2Bb", JenkinsResultsParserUtil.encodeURLParameter("a+b"));
+		testEquals(
+			"master", JenkinsResultsParserUtil.encodeURLParameter("master"));
+	}
+
 	@Test(timeout = 30000)
 	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
 		try (ServerSocket serverSocket = _createServerSocket()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7942

Companion to https://github.com/CalumR23/liferay-jenkins-ee/pull/1.

Supersedes https://github.com/pyoo47/liferay-portal/pull/4482, which passed `ci:test:sf` and was forwarded to https://github.com/brianchandotcom/liferay-portal/pull/179506 before being closed with a rebase error.

## What Is Being Fixed

Downstream job invocation parameters are round tripped through a URL string, and the round trip corrupts any value containing a reserved character.

The invocation URL is URL-decoded as a whole string twice, once in `BaseParentBuild.addDownstreamBuilds` and again in `BaseBuild._setInvocationURL`, before `loadParametersFromQueryString` splits the query string on the ampersand. Decoding before splitting destroys the parameter boundaries:

- An encoded ampersand in a value becomes a real ampersand, so the value is silently truncated at the split and the remainder is discarded. `TESTRAY_PROJECT_NAME=AWS %26 CI` arrives as `AWS `.
- A bare percent sign makes `URLDecoder.decode` throw `IllegalArgumentException: Illegal hex characters in escape (%) pattern`. `addDownstreamBuilds` catches only `UnsupportedEncodingException`, so the exception escapes and kills the parent build outright.

The pound sign case originally reported on the ticket, observed on test-1-43 test-jenkins-acceptance-pullrequest build 175 as three consecutive 405 Method Not Allowed responses, is already resolved on master: `invokeJenkinsBuild` now POSTs an `application/x-www-form-urlencoded` body rather than appending a query string, so there is no longer a query string for the pound sign to truncate. This PR is scoped to the two cases that remain.

## How It Is Being Fixed

`loadParametersFromQueryString` now splits the query string while it is still encoded and decodes each name and value individually, and the two whole-string decodes ahead of it are removed. Splitting uses a limit of two so an `=` inside a value survives. Decoding a single parameter that carries an invalid escape falls back to its raw value rather than failing the build, so one malformed value can no longer take down a parent build.

`JenkinsResultsParserUtil.encodeURLParameter(String)` is the counterpart the Ant layer uses to encode each parameter as it builds the invocation URL, which is what keeps the split unambiguous. The companion PR applies it in `commands/build-common.xml`.

## PR Check

**pr-check: PASS** — tested on `e16e3733c11b09b95b3bff43a2774f577f7b3847`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

Java Unit Tests: `JenkinsResultsParserUtilTest` 21 tests and `BaseBuildTest` 5 tests, 0 failures and 0 errors, including `testEncodeURLParameter`, `testLoadParametersFromQueryString`, and `testLoadParametersFromQueryStringIllegalEscape`.

Because this branch changes shared build plumbing, the full module suite was run as a regression sweep: 59 classes, with failures confined to the classes that already fail in a renamed worktree for environmental reasons (`LocalGitBranchTest`, `LocalGitRepositoryTest`, `BatchTestClassGroupTest`, `ServiceBuilderModulesBatchTestClassGroupTest`, `RelevantRuleEngineTest`, `RelevantRuleValidationTest`, `RelevantTestSuiteTest`). Nothing failed outside that baseline, and every build object test passed: `BaseBuildTest`, `BaseDownstreamBuildTest`, `BaseBuildUpdaterTest`, `DefaultBuildUpdaterTest`, `DefaultBuildDatabaseTest`, `BuildQueueRebalancerTest`.

Per-Module Compile: `ant compile install-portal-snapshots`, then `:test:jenkins-results-parser:deploy`, then `compileJava` and `compileTestJava` re-run with `--rerun-tasks`. The forced runs are the deciding evidence, because `deploy` reports `compileJava` UP-TO-DATE on a warm worktree, and this branch removed import lines from two files where only a real compile would catch a dangling reference.

Cross-Module Compile matched on `JenkinsResultsParserUtil.java` via the `*Util.java` rule, but nothing in the repository consumes `jenkins-results-parser` as a Gradle dependency, so there were no consumer modules to compile.

<!-- pr-check {"result": "success", "sha": "e16e3733c11b09b95b3bff43a2774f577f7b3847"} -->

