### PR TITLE
LRCI-7931 Stop logging failed REST API calls for queued items

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuildUpdater.java
@@ -71,18 +71,18 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 	}
 
 	protected void runMissing() {
-		if (isBuildQueued()) {
-			_missingTickCount = 0;
-
-			_build.setStatus("queued");
-
-			return;
-		}
-
 		if (isBuildRunning()) {
 			_missingTickCount = 0;
 
 			_build.setStatus("running");
+
+			return;
+		}
+
+		if (isBuildQueued()) {
+			_missingTickCount = 0;
+
+			_build.setStatus("queued");
 
 			return;
 		}
@@ -123,13 +123,13 @@ public abstract class BaseBuildUpdater implements BuildUpdater {
 	}
 
 	protected void runQueued() {
-		if (isBuildQueued()) {
-			return;
-		}
-
 		if (isBuildRunning()) {
 			_build.setStatus("running");
 
+			return;
+		}
+
+		if (isBuildQueued()) {
 			return;
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -657,18 +657,23 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	public QueueItem getQueueItem(long queueId) {
+		String queueItemAPIURL = JenkinsResultsParserUtil.combine(
+			getURL(), "/queue/item/", String.valueOf(queueId),
+			"/api/json?tree=actions[parameters[name,value]],",
+			"id,inQueueSince,task[name,url],url,why");
+
 		try {
+			String response = JenkinsResultsParserUtil.toString(
+				queueItemAPIURL, false, 0, 0, 5000);
+
+			if (JenkinsResultsParserUtil.isNullOrEmpty(response)) {
+				return null;
+			}
+
 			JSONObject queueItemJSONObject =
-				JenkinsResultsParserUtil.toJSONObject(
-					JenkinsResultsParserUtil.combine(
-						getURL(), "/queue/item/", String.valueOf(queueId),
-						"/api/json?tree=actions[parameters[name,value]],",
-						"id,inQueueSince,task[name,url],url,why"),
-					false, 5000);
+				JenkinsResultsParserUtil.createJSONObject(response);
 
-			if ((queueItemJSONObject == null) ||
-				!queueItemJSONObject.has("id")) {
-
+			if (!queueItemJSONObject.has("id")) {
 				return null;
 			}
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsMasterTest.java
@@ -5,7 +5,10 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintStream;
 
 import java.util.Map;
 
@@ -88,6 +91,56 @@ public class JenkinsMasterTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertEquals(
 			availableSlavesCount, _jenkinsMaster.getAvailableSlavesCount(null));
+	}
+
+	@Test
+	public void testGetQueueItem() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		setUrlReaderOutput(
+			new JSONObject(
+			).put(
+				"id", 7800
+			).toString(),
+			"http://test-9-1/queue/item/7800/api/json", urlReader);
+
+		JenkinsMaster.QueueItem queueItem = _jenkinsMaster.getQueueItem(7800);
+
+		Assert.assertEquals(7800, queueItem.getId());
+	}
+
+	@Test
+	public void testGetQueueItemNotFound() throws Exception {
+		UrlReader urlReader = mockUrlReader();
+
+		String queueItemAPIURL = "http://test-9-1/queue/item/7800/api/json";
+
+		Mockito.doThrow(
+			new FileNotFoundException(queueItemAPIURL)
+		).when(
+			urlReader
+		).doRead(
+			Mockito.anyBoolean(), Mockito.any(), Mockito.any(),
+			Mockito.anyInt(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt(),
+			Mockito.argThat(
+				readURL ->
+					(readURL != null) && readURL.contains(queueItemAPIURL))
+		);
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+		PrintStream printStream = System.out;
+
+		System.setOut(new PrintStream(byteArrayOutputStream, true));
+
+		try {
+			Assert.assertNull(_jenkinsMaster.getQueueItem(7800));
+		}
+		finally {
+			System.setOut(printStream);
+		}
+
+		Assert.assertEquals("", byteArrayOutputStream.toString());
 	}
 
 	@Test


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7931

## What Is Being Fixed

A queue item disappears from Jenkins as soon as its build starts, so polling a downstream build that has already left the queue answers 404. That answer was routed through `toJSONObject`, which retries three times and prints on every failure, so each started-but-still-queued build added four lines to the top level build log on every tick. With dozens of downstream builds this floods the log and buries genuine errors.

## How It Is Being Fixed

`JenkinsMaster.getQueueItem` now fetches the queue item through `toString`, which neither retries nor prints, and treats the resulting `FileNotFoundException` as the expected negative answer. The caller contract is unchanged: `null` on failure, as before.

`BaseBuildUpdater` also checks `isBuildRunning` before `isBuildQueued` in `runQueued` and `runMissing`, which avoids the call altogether in the common case and fixes the ordering bug where a running build read as still queued. The running check reads the cached bulk builds API response that is already fetched every tick, so it costs no extra request.

## Revision History

Supersedes pyoo47#4486, pyoo47#4488 and brianchandotcom#179557.

Addresses @brianchandotcom's review on brianchandotcom#179557 — `setUrlReaderException` had a single caller, so the `Mockito.doThrow` stub is now inlined into `testGetQueueItemNotFound` and the shared `Test.java` base class is left untouched.

Retains the commit split @pyoo47 applied in pyoo47#4488: the implementation lands first, the unit tests follow in their own commit.

Per @pyoo47's follow-up on pyoo47#4486, the `getQueueItem` half is deliberately interim. The structural consolidation of the three retry layers is [LRCI-7996](https://liferay.atlassian.net/browse/LRCI-7996), which removes this hunk when it lands. The `BaseBuildUpdater` reordering is independent and stays permanently.

## PR Check

**pr-check: PASS** — tested on `09481d6a588702070bbb95f7f7aa01df8e0ee48a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "09481d6a588702070bbb95f7f7aa01df8e0ee48a"} -->
