### PR TITLE
LRCI-7942 Stop round tripping invocation parameters through a decoded URL

### DIFF
--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -3099,13 +3099,15 @@ public abstract class BaseBuild implements Build {
 				continue;
 			}
 
-			String[] nameValueArray = parameter.split("=");
+			String[] parameterParts = parameter.split("=", 2);
 
-			if (nameValueArray.length == 2) {
-				_parameters.put(nameValueArray[0], nameValueArray[1]);
+			String name = _decodeParameterPart(parameterParts[0]);
+
+			if (parameterParts.length == 2) {
+				_parameters.put(name, _decodeParameterPart(parameterParts[1]));
 			}
-			else if (nameValueArray.length == 1) {
-				_parameters.put(nameValueArray[0], "");
+			else {
+				_parameters.put(name, "");
 			}
 		}
 	}
@@ -3317,6 +3319,19 @@ public abstract class BaseBuild implements Build {
 
 	private void _archiveTestReportJSON() {
 		_archive(null, false, "testReport/api/json");
+	}
+
+	private String _decodeParameterPart(String parameterPart) {
+		try {
+			return JenkinsResultsParserUtil.decode(parameterPart);
+		}
+		catch (Exception exception) {
+			System.out.println(
+				"Unable to decode the query string parameter part " +
+					parameterPart);
+
+			return parameterPart;
+		}
 	}
 
 	private int _getMaximumInvocationCount() {
@@ -3643,15 +3658,6 @@ public abstract class BaseBuild implements Build {
 			return;
 		}
 
-		try {
-			invocationURL = JenkinsResultsParserUtil.decode(invocationURL);
-		}
-		catch (UnsupportedEncodingException unsupportedEncodingException) {
-			throw new IllegalArgumentException(
-				"Unable to decode " + invocationURL,
-				unsupportedEncodingException);
-		}
-
 		Matcher invocationURLMatcher = _invocationURLPattern.matcher(
 			invocationURL);
 
@@ -3659,7 +3665,7 @@ public abstract class BaseBuild implements Build {
 			throw new RuntimeException("Invalid invocation URL");
 		}
 
-		setJobName(invocationURLMatcher.group("jobName"));
+		setJobName(_decodeParameterPart(invocationURLMatcher.group("jobName")));
 
 		JenkinsCohort jenkinsCohort = JenkinsCohort.getInstance(
 			invocationURLMatcher.group("cohortName"));

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseParentBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseParentBuild.java
@@ -8,7 +8,6 @@ package com.liferay.jenkins.results.parser;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -72,14 +71,7 @@ public abstract class BaseParentBuild extends BaseBuild implements ParentBuild {
 		for (Map.Entry<String, String> urlEntry : urlAxisNames.entrySet()) {
 			String url = urlEntry.getKey();
 
-			try {
-				url = JenkinsResultsParserUtil.getLocalURL(
-					JenkinsResultsParserUtil.decode(url));
-			}
-			catch (UnsupportedEncodingException unsupportedEncodingException) {
-				throw new IllegalArgumentException(
-					"Unable to decode " + url, unsupportedEncodingException);
-			}
+			url = JenkinsResultsParserUtil.getLocalURL(url);
 
 			if (!hasBuildURL(url)) {
 				final String axisName = urlEntry.getValue();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -510,6 +510,18 @@ public class JenkinsResultsParserUtil {
 		return new URL(uriASCIIString.replace("#", "%23"));
 	}
 
+	public static String encodeURLParameterPart(String parameterPart) {
+		try {
+			parameterPart = URLEncoder.encode(
+				parameterPart, StandardCharsets.UTF_8.name());
+
+			return parameterPart.replace("+", "%20");
+		}
+		catch (UnsupportedEncodingException unsupportedEncodingException) {
+			throw new RuntimeException(unsupportedEncodingException);
+		}
+	}
+
 	public static String escapeForBash(String string) {
 		string = string.replaceAll(" ", "\\\\ ");
 		string = string.replaceAll("'", "\\\\\\\'");

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -8,7 +8,9 @@ package com.liferay.jenkins.results.parser;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -64,6 +66,63 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 
 		Assert.assertEquals(
 			Arrays.asList(firstBuildURL), baseBuild.getBadBuildURLs());
+	}
+
+	@Test
+	public void testLoadParametersFromQueryString() {
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuild, "_parameters", new HashMap<String, String>());
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).loadParametersFromQueryString(
+			Mockito.anyString()
+		);
+
+		baseBuild.loadParametersFromQueryString(
+			JenkinsResultsParserUtil.combine(
+				"token=abc123&PORTAL_BATCH_TEST_SELECTOR=PortalSmoke%23Smoke",
+				"&TESTRAY_PROJECT_NAME=AWS%20%26%20CI",
+				"&PORTAL_BUILD_NOTES=100%25%20pass&PORTAL_UPSTREAM=master",
+				"&AXIS_VARIABLE=&PORTAL_QUERY=a%3Db"));
+
+		Map<String, String> parameters = ReflectionTestUtil.getFieldValue(
+			baseBuild, "_parameters");
+
+		Assert.assertEquals(
+			"PortalSmoke#Smoke", parameters.get("PORTAL_BATCH_TEST_SELECTOR"));
+		Assert.assertEquals("AWS & CI", parameters.get("TESTRAY_PROJECT_NAME"));
+		Assert.assertEquals("100% pass", parameters.get("PORTAL_BUILD_NOTES"));
+		Assert.assertEquals("master", parameters.get("PORTAL_UPSTREAM"));
+		Assert.assertEquals("", parameters.get("AXIS_VARIABLE"));
+		Assert.assertEquals("a=b", parameters.get("PORTAL_QUERY"));
+	}
+
+	@Test
+	public void testLoadParametersFromQueryStringIllegalEscape() {
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuild, "_parameters", new HashMap<String, String>());
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).loadParametersFromQueryString(
+			Mockito.anyString()
+		);
+
+		baseBuild.loadParametersFromQueryString(
+			"PORTAL_BUILD_NOTES=100% pass&PORTAL_UPSTREAM=master");
+
+		Map<String, String> parameters = ReflectionTestUtil.getFieldValue(
+			baseBuild, "_parameters");
+
+		Assert.assertEquals("100% pass", parameters.get("PORTAL_BUILD_NOTES"));
+		Assert.assertEquals("master", parameters.get("PORTAL_UPSTREAM"));
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -28,6 +28,27 @@ import org.mockito.Mockito;
 public class JenkinsResultsParserUtilTest
 	extends com.liferay.jenkins.results.parser.Test {
 
+	@Test
+	public void testEncodeURLParameterPart() {
+		testEquals(
+			"PortalSmoke%23Smoke",
+			JenkinsResultsParserUtil.encodeURLParameterPart(
+				"PortalSmoke#Smoke"));
+		testEquals(
+			"AWS%20CI",
+			JenkinsResultsParserUtil.encodeURLParameterPart("AWS CI"));
+		testEquals(
+			"a%26b", JenkinsResultsParserUtil.encodeURLParameterPart("a&b"));
+		testEquals(
+			"100%25%20pass",
+			JenkinsResultsParserUtil.encodeURLParameterPart("100% pass"));
+		testEquals(
+			"a%2Bb", JenkinsResultsParserUtil.encodeURLParameterPart("a+b"));
+		testEquals(
+			"master",
+			JenkinsResultsParserUtil.encodeURLParameterPart("master"));
+	}
+
 	@Test(timeout = 30000)
 	public void testExecuteJenkinsScriptReadTimeout() throws Exception {
 		try (ServerSocket serverSocket = _createServerSocket()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7942

Companion to https://github.com/CalumR23/liferay-jenkins-ee/pull/16.

Resend of https://github.com/CalumR23/liferay-portal/pull/531, which was forwarded to https://github.com/brianchandotcom/liferay-portal/pull/179654 and closed with review feedback.

## What Is Being Fixed

Downstream job invocation parameters are round tripped through a URL string, and the round trip corrupts any value containing a reserved character.

The invocation URL is URL-decoded as a whole string twice, once in `BaseParentBuild.addDownstreamBuilds` and again in `BaseBuild._setInvocationURL`, before `loadParametersFromQueryString` splits the query string on the ampersand. Decoding before splitting destroys the parameter boundaries:

- An encoded ampersand in a value becomes a real ampersand, so the value is silently truncated at the split and the remainder is discarded. `TESTRAY_PROJECT_NAME=AWS %26 CI` arrives as `AWS `.
- A bare percent sign makes `URLDecoder.decode` throw `IllegalArgumentException: Illegal hex characters in escape (%) pattern`. `addDownstreamBuilds` catches only `UnsupportedEncodingException`, so the exception escapes and kills the parent build outright.

The pound sign case originally reported on the ticket is already resolved on master, because `invokeJenkinsBuild` now POSTs an `application/x-www-form-urlencoded` body rather than appending a query string. This PR is scoped to the two cases that remain, which still apply to the downstream invocation path in `commands/build-common.xml`, the one place that still hands a hand built query string to `addDownstreamBuilds`.

## How It Is Being Fixed

`loadParametersFromQueryString` now splits the query string while it is still encoded and decodes each name and value individually, and the two whole-string decodes ahead of it are removed. Splitting uses a limit of two so an `=` inside a value survives. Decoding a single part that carries an invalid escape falls back to its raw text rather than failing the build, so one malformed value can no longer take down a parent build.

`JenkinsResultsParserUtil.encodeURLParameterPart(String)` is the counterpart the Ant layer uses to encode each name and each value as it builds the invocation URL, which is what keeps the split unambiguous. The companion PR applies it.

## Review Feedback Applied

- Applied the `nameValueArray` to `parameterParts` rename verbatim.
- Answering "is `string` a parameter (x=5), a parameterName (x), or a parameterValue (5)?": it is neither a whole parameter nor specifically a name or a value, because the helper is called once for the name and once for the value. Renamed `encodeURLParameter` to `encodeURLParameterPart` with a `parameterPart` argument, matching the `parameterParts` vocabulary from the review diff. The private counterpart `_decodeParameter` had the same ambiguity and is now `_decodeParameterPart`; that rename goes beyond the supplied diff, so say the word if you would rather it stayed.

One asymmetry worth flagging: `PARENT_BUILD_URL` is still appended raw immediately after `buildWithParameters?` in `commands/build-common.xml`, outside the loop this change encodes. It round trips correctly today because a build URL carries no percent escapes, so I left it alone rather than widen the diff.

## PR Check

**pr-check: PASS** — tested on `6a6aca339f251f9b05f85b711204f30939e310a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

Java Unit Tests: `JenkinsResultsParserUtilTest` 21 tests and `BaseBuildTest` 5 tests, 0 failures and 0 errors, including `testEncodeURLParameterPart`, `testLoadParametersFromQueryString`, and `testLoadParametersFromQueryStringIllegalEscape`.

Full module suite run as a regression sweep, since this branch changes shared build plumbing: 182 tests, 15 failures, all confined to the classes that already fail in a renamed worktree for environmental reasons. Nothing failed outside that baseline, and every build object test passed: `BaseBuildTest`, `BaseDownstreamBuildTest`, `BaseBuildUpdaterTest`, `DefaultBuildUpdaterTest`, `DefaultBuildDatabaseTest`, `BuildQueueRebalancerTest`.

Per-Module Compile: `ant compile install-portal-snapshots`, then `deploy`, then `compileJava` and `compileTestJava` re-run with `--rerun-tasks`, since `deploy` reported `compileJava` UP-TO-DATE. A grep confirms no stale references to the old identifiers remain.

Cross-Module Compile matched on the `*Util.java` rule, but nothing in the repository consumes `jenkins-results-parser` as a Gradle dependency, so there were no consumer modules to compile.

<!-- pr-check {"result": "success", "sha": "6a6aca339f251f9b05f85b711204f30939e310a4"} -->

