### PR TITLE
LRCI-7983 Build the CI infrastructure URLs with URLBuilderUtil

### DIFF
--- a/modules/test/jenkins-results-parser/build.gradle
+++ b/modules/test/jenkins-results-parser/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	api group: "org.apache.ant", name: "ant", version: "1.10.14"
 	api group: "org.apache.commons", name: "commons-compress", version: "1.26.0"
 	api group: "org.apache.commons", name: "commons-lang3", version: "3.18.0"
+	api group: "org.apache.httpcomponents", name: "httpclient", version: "4.5.13"
 	api group: "org.dom4j", name: "dom4j", version: "2.1.3"
 	api group: "org.json", name: "json", version: "20231013"
 	testImplementation group: "org.mockito", name: "mockito-core", version: "4.5.1"

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -800,26 +800,8 @@ public abstract class BaseBuild implements Build {
 			return null;
 		}
 
-		StringBuffer sb = new StringBuffer(jobURL);
-
-		sb.append("/buildWithParameters?");
-
-		Map<String, String> parameters = new HashMap<>(getParameters());
-
-		for (Map.Entry<String, String> parameter : parameters.entrySet()) {
-			sb.append(
-				JenkinsResultsParserUtil.encodeURLParameterPart(
-					parameter.getKey()));
-			sb.append("=");
-			sb.append(
-				JenkinsResultsParserUtil.encodeURLParameterPart(
-					parameter.getValue()));
-			sb.append("&");
-		}
-
-		sb.deleteCharAt(sb.length() - 1);
-
-		return sb.toString();
+		return URLBuilderUtil.buildURL(
+			jobURL + "/buildWithParameters", getParameters());
 	}
 
 	@Override
@@ -3657,8 +3639,11 @@ public abstract class BaseBuild implements Build {
 			JenkinsResultsParserUtil.decodeURLParameterPart(
 				invocationURLMatcher.group("jobName")));
 
-		loadParametersFromQueryString(
-			invocationURLMatcher.group("queryString"));
+		String queryString = invocationURLMatcher.group("queryString");
+
+		if (queryString != null) {
+			loadParametersFromQueryString(queryString);
+		}
 
 		String masterId = invocationURLMatcher.group("masterId");
 
@@ -3701,7 +3686,7 @@ public abstract class BaseBuild implements Build {
 		JenkinsResultsParserUtil.combine(
 			"\\w+://(?<cohortName>test-\\d+)(-(?<masterId>\\d+))?",
 			"(\\.liferay\\.com)?/+job\\/+(?<jobName>[^\\/]+).*\\/",
-			"buildWithParameters\\?(?<queryString>.*)"));
+			"buildWithParameters(\\?(?<queryString>.*))?"));
 	private static final Pattern _testrayCloudObjectURLPattern =
 		Pattern.compile(
 			JenkinsResultsParserUtil.combine(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 
 import java.text.ParseException;
@@ -963,13 +962,7 @@ public abstract class BaseBuild implements Build {
 		String jobURL = JenkinsResultsParserUtil.combine(
 			jenkinsMaster.getRemoteURL(), "job/", _jobName);
 
-		try {
-			return JenkinsResultsParserUtil.encode(jobURL);
-		}
-		catch (MalformedURLException | URISyntaxException exception) {
-			throw new RuntimeException(
-				"Unable to encode job URL " + jobURL, exception);
-		}
+		return URLBuilderUtil.normalizeURL(jobURL);
 	}
 
 	@Override

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -3213,11 +3213,6 @@ public abstract class BaseBuild implements Build {
 
 		String urlString = getBuildURL() + urlSuffix;
 
-		// Left as concatenation. The suffix carries no value, so it cannot be
-		// corrupted, and an archive URL may be a file URL or still hold the
-		// unresolved dependencies token, neither of which parses as a URI
-		// reference
-
 		if (urlString.endsWith("json")) {
 			urlString += "?pretty";
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -3213,6 +3213,11 @@ public abstract class BaseBuild implements Build {
 
 		String urlString = getBuildURL() + urlSuffix;
 
+		// Left as concatenation. The suffix carries no value, so it cannot be
+		// corrupted, and an archive URL may be a file URL or still hold the
+		// unresolved dependencies token, neither of which parses as a URI
+		// reference
+
 		if (urlString.endsWith("json")) {
 			urlString += "?pretty";
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseBuild.java
@@ -3080,18 +3080,17 @@ public abstract class BaseBuild implements Build {
 	}
 
 	protected void loadParametersFromQueryString(String queryString) {
-		for (String parameter : queryString.split("&")) {
-			if (!parameter.contains("=")) {
+		Map<String, String> parameters = URLBuilderUtil.parseQueryString(
+			queryString);
+
+		for (Map.Entry<String, String> entry : parameters.entrySet()) {
+			String value = entry.getValue();
+
+			if (value == null) {
 				continue;
 			}
 
-			String[] parameterParts = parameter.split("=", 2);
-
-			_parameters.put(
-				JenkinsResultsParserUtil.decodeURLParameterPart(
-					parameterParts[0]),
-				JenkinsResultsParserUtil.decodeURLParameterPart(
-					parameterParts[1]));
+			_parameters.put(entry.getKey(), value);
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
@@ -1424,19 +1424,18 @@ public abstract class BaseJob implements Job {
 			return null;
 		}
 
-		StringBuffer sb = new StringBuffer();
-
-		sb.append(
-			JenkinsResultsParserUtil.getLocalURL(getJobURL(jenkinsMaster)));
-		sb.append("/api/json?pretty");
+		String apiURL = URLBuilderUtil.buildURL(
+			JenkinsResultsParserUtil.combine(
+				JenkinsResultsParserUtil.getLocalURL(getJobURL(jenkinsMaster)),
+				"/api/json"),
+			"pretty", null);
 
 		if (tree != null) {
-			sb.append("&tree=");
-			sb.append(tree);
+			apiURL = URLBuilderUtil.appendParameter(apiURL, "tree", tree);
 		}
 
 		try {
-			return JenkinsResultsParserUtil.toJSONObject(sb.toString(), false);
+			return JenkinsResultsParserUtil.toJSONObject(apiURL, false);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException("Unable to get job JSON", ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseJob.java
@@ -1431,7 +1431,7 @@ public abstract class BaseJob implements Job {
 			"pretty", null);
 
 		if (tree != null) {
-			apiURL = URLBuilderUtil.appendParameter(apiURL, "tree", tree);
+			apiURL = URLBuilderUtil.buildURL(apiURL, "tree", tree);
 		}
 
 		try {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BasePortalControllerBuildRunner.java
@@ -311,8 +311,10 @@ public abstract class BasePortalControllerBuildRunner
 
 			try {
 				JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-					JenkinsResultsParserUtil.getLocalURL(
-						buildURL + "/api/json?tree=result"));
+					URLBuilderUtil.buildURL(
+						JenkinsResultsParserUtil.getLocalURL(
+							buildURL + "/api/json"),
+						"tree", "result"));
 
 				Object result = jsonObject.get("result");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTestClassResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTestClassResult.java
@@ -10,8 +10,6 @@ import com.liferay.jenkins.results.parser.test.clazz.JUnitTestClass;
 import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 import com.liferay.jenkins.results.parser.test.clazz.group.AxisTestClassGroup;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 
 import java.util.ArrayList;
@@ -234,13 +232,7 @@ public abstract class BaseTestClassResult implements TestClassResult {
 		String testClassReportURL = sb.toString();
 
 		if (testClassReportURL.startsWith("http")) {
-			try {
-				return JenkinsResultsParserUtil.encode(testClassReportURL);
-			}
-			catch (MalformedURLException | URISyntaxException exception) {
-				System.out.println(
-					"Unable to encode the test report " + testClassReportURL);
-			}
+			return URLBuilderUtil.normalizeURL(testClassReportURL);
 		}
 
 		return testClassReportURL;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseTopLevelBuild.java
@@ -622,7 +622,8 @@ public abstract class BaseTopLevelBuild
 
 		try {
 			JSONObject buildJSONObject = JenkinsResultsParserUtil.toJSONObject(
-				buildURL + "/api/json?tree=result");
+				URLBuilderUtil.buildURL(
+					buildURL + "/api/json", "tree", "result"));
 
 			if (!JenkinsResultsParserUtil.isNullOrEmpty(
 					buildJSONObject.optString("result", null))) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildFactory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildFactory.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 
+import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 
@@ -68,9 +69,15 @@ public class BuildFactory {
 		if (jobName.contains("-downstream")) {
 			String queryString = matcher.group("queryString");
 
-			if ((queryString != null) && queryString.contains("JOB_VARIANT")) {
-				jobVariant = queryString.replaceAll(
-					".*JOB_VARIANT=([^&]+).*", "$1");
+			Map<String, String> parameters = URLBuilderUtil.parseQueryString(
+				queryString);
+
+			String queryStringJobVariant = parameters.get("JOB_VARIANT");
+
+			if (!JenkinsResultsParserUtil.isNullOrEmpty(
+					queryStringJobVariant)) {
+
+				jobVariant = queryStringJobVariant;
 			}
 
 			if (JenkinsResultsParserUtil.isNullOrEmpty(jobVariant)) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildQueueRebalancer.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BuildQueueRebalancer.java
@@ -459,9 +459,11 @@ public class BuildQueueRebalancer {
 		private boolean _isBuildInProgress(String buildURL) {
 			try {
 				JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-					JenkinsResultsParserUtil.combine(
-						JenkinsResultsParserUtil.getLocalURL(buildURL),
-						"/api/json?tree=result"),
+					URLBuilderUtil.buildURL(
+						JenkinsResultsParserUtil.combine(
+							JenkinsResultsParserUtil.getLocalURL(buildURL),
+							"/api/json"),
+						"tree", "result"),
 					false, 5000);
 
 				String result = jsonObject.optString("result");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CentralGitSubrepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/CentralGitSubrepository.java
@@ -200,8 +200,7 @@ public class CentralGitSubrepository {
 
 		for (int i = 0; i < 15; i++) {
 			JSONArray statusesJSONArray = JenkinsResultsParserUtil.toJSONArray(
-				JenkinsResultsParserUtil.combine(
-					url, "?page=", String.valueOf(i + 1)),
+				URLBuilderUtil.buildURL(url, "page", String.valueOf(i + 1)),
 				true);
 
 			if ((statusesJSONArray == null) ||

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GenerateReportsControllerBuildRunner.java
@@ -94,14 +94,15 @@ public class GenerateReportsControllerBuildRunner
 
 		BuildData buildData = getBuildData();
 
-		StringBuilder sb = new StringBuilder();
-
-		sb.append(JenkinsResultsParserUtil.getLocalURL(buildData.getJobURL()));
-		sb.append("/api/json?tree=builds[description,timestamp,url]");
+		String jobAPIURL = URLBuilderUtil.buildURL(
+			JenkinsResultsParserUtil.combine(
+				JenkinsResultsParserUtil.getLocalURL(buildData.getJobURL()),
+				"/api/json"),
+			"tree", "builds[description,timestamp,url]");
 
 		try {
 			JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-				sb.toString(), false);
+				jobAPIURL, false);
 
 			JSONArray buildsJSONArray = jsonObject.getJSONArray("builds");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteGitRepository.java
@@ -132,13 +132,15 @@ public class GitHubRemoteGitRepository extends BaseRemoteGitRepository {
 			 pageNumber++) {
 
 			try {
+				String labelsURL = URLBuilderUtil.buildURL(
+					labelRequestURL, "per_page",
+					String.valueOf(
+						JenkinsResultsParserUtil.
+							PER_PAGE_GITHUB_API_PAGES_SIZE_MAX));
+
 				labelsJSONArray = JenkinsResultsParserUtil.toJSONArray(
-					JenkinsResultsParserUtil.combine(
-						labelRequestURL, "?per_page=",
-						String.valueOf(
-							JenkinsResultsParserUtil.
-								PER_PAGE_GITHUB_API_PAGES_SIZE_MAX),
-						"&page=", String.valueOf(pageNumber)),
+					URLBuilderUtil.appendParameter(
+						labelsURL, "page", String.valueOf(pageNumber)),
 					false);
 			}
 			catch (IOException ioException) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitHubRemoteGitRepository.java
@@ -126,20 +126,19 @@ public class GitHubRemoteGitRepository extends BaseRemoteGitRepository {
 
 		Set<Label> labels = new HashSet<>();
 
+		String labelsURL = URLBuilderUtil.buildURL(
+			labelRequestURL, "per_page",
+			String.valueOf(
+				JenkinsResultsParserUtil.PER_PAGE_GITHUB_API_PAGES_SIZE_MAX));
+
 		for (int pageNumber = 1;
 			 pageNumber <=
 				 JenkinsResultsParserUtil.PAGES_GITHUB_API_PAGES_SIZE_MAX;
 			 pageNumber++) {
 
 			try {
-				String labelsURL = URLBuilderUtil.buildURL(
-					labelRequestURL, "per_page",
-					String.valueOf(
-						JenkinsResultsParserUtil.
-							PER_PAGE_GITHUB_API_PAGES_SIZE_MAX));
-
 				labelsJSONArray = JenkinsResultsParserUtil.toJSONArray(
-					URLBuilderUtil.appendParameter(
+					URLBuilderUtil.buildURL(
 						labelsURL, "page", String.valueOf(pageNumber)),
 					false);
 			}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JUnitTestResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JUnitTestResult.java
@@ -10,8 +10,6 @@ import com.liferay.jenkins.results.parser.test.clazz.TestClass;
 
 import java.io.IOException;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
 import java.net.URL;
 
 import java.util.Date;
@@ -204,13 +202,7 @@ public class JUnitTestResult extends BaseTestResult {
 		String testReportURL = sb.toString();
 
 		if (testReportURL.startsWith("http")) {
-			try {
-				return JenkinsResultsParserUtil.encode(testReportURL);
-			}
-			catch (MalformedURLException | URISyntaxException exception) {
-				System.out.println(
-					"Unable to encode the test report " + testReportURL);
-			}
+			return URLBuilderUtil.normalizeURL(testReportURL);
 		}
 
 		return testReportURL;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsAPIUtil.java
@@ -27,17 +27,14 @@ public class JenkinsAPIUtil {
 			return null;
 		}
 
-		StringBuffer sb = new StringBuffer();
-
-		sb.append(JenkinsResultsParserUtil.getLocalURL(jenkinsURL));
-		sb.append("/api/json");
+		String apiURL = JenkinsResultsParserUtil.combine(
+			JenkinsResultsParserUtil.getLocalURL(jenkinsURL), "/api/json");
 
 		if (tree != null) {
-			sb.append("?tree=");
-			sb.append(tree);
+			apiURL = URLBuilderUtil.buildURL(apiURL, "tree", tree);
 		}
 
-		final String jenkinsAPIURL = sb.toString();
+		final String jenkinsAPIURL = apiURL;
 
 		Retryable<JSONObject> retryable = new Retryable<JSONObject>() {
 
@@ -102,18 +99,16 @@ public class JenkinsAPIUtil {
 	public static JSONObject getLastCompletedBuildJSONObject(
 		String jobURL, String tree) {
 
-		StringBuffer sb = new StringBuffer();
-
-		sb.append(JenkinsResultsParserUtil.getLocalURL(jobURL));
-		sb.append("/lastCompletedBuild/api/json");
+		String apiURL = JenkinsResultsParserUtil.combine(
+			JenkinsResultsParserUtil.getLocalURL(jobURL),
+			"/lastCompletedBuild/api/json");
 
 		if (tree != null) {
-			sb.append("?tree=");
-			sb.append(tree);
+			apiURL = URLBuilderUtil.buildURL(apiURL, "tree", tree);
 		}
 
 		try {
-			return JenkinsResultsParserUtil.toJSONObject(sb.toString(), false);
+			return JenkinsResultsParserUtil.toJSONObject(apiURL, false);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException("Unable to get build JSON", ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsMaster.java
@@ -410,10 +410,13 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 		try {
 			JSONObject jobJSONObject = JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					getURL(), "/job/", jobName, "/api/json?",
-					"tree=builds[actions[parameters[name,value]],queueId,",
-					"result,url]"),
+				URLBuilderUtil.buildURL(
+					JenkinsResultsParserUtil.combine(
+						getURL(), "/job/", jobName, "/api/json"),
+					"tree",
+					JenkinsResultsParserUtil.combine(
+						"builds[actions[parameters[name,value]],queueId,",
+						"result,url]")),
 				false, 5000);
 
 			JSONArray buildsJSONArray = jobJSONObject.optJSONArray("builds");
@@ -576,9 +579,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 		try {
 			JSONObject queueJSONObject = JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					getURL(), "/queue/api/json?",
-					"tree=items[actions[parameters[name,value]],id,task[url]]"),
+				URLBuilderUtil.buildURL(
+					getURL() + "/queue/api/json", "tree",
+					"items[actions[parameters[name,value]],id,task[url]]"),
 				false, 5000);
 
 			JSONArray itemsJSONArray = queueJSONObject.optJSONArray("items");
@@ -657,10 +660,13 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 	}
 
 	public QueueItem getQueueItem(long queueId) {
-		String queueItemAPIURL = JenkinsResultsParserUtil.combine(
-			getURL(), "/queue/item/", String.valueOf(queueId),
-			"/api/json?tree=actions[parameters[name,value]],",
-			"id,inQueueSince,task[name,url],url,why");
+		String queueItemAPIURL = URLBuilderUtil.buildURL(
+			JenkinsResultsParserUtil.combine(
+				getURL(), "/queue/item/", String.valueOf(queueId), "/api/json"),
+			"tree",
+			JenkinsResultsParserUtil.combine(
+				"actions[parameters[name,value]],",
+				"id,inQueueSince,task[name,url],url,why"));
 
 		try {
 			String response = JenkinsResultsParserUtil.toString(
@@ -716,10 +722,11 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		try {
 			JSONObject queueAPIJSONObject =
 				JenkinsResultsParserUtil.toJSONObject(
-					JenkinsResultsParserUtil.combine(
-						getURL(), "/queue/api/json?tree=items[actions[",
-						"parameters[name,value]],id,inQueueSince,",
-						"task[name,url],url,why]"),
+					URLBuilderUtil.buildURL(
+						getURL() + "/queue/api/json", "tree",
+						JenkinsResultsParserUtil.combine(
+							"items[actions[parameters[name,value]],id,",
+							"inQueueSince,task[name,url],url,why]")),
 					false, 5000);
 
 			if (!queueAPIJSONObject.has("items")) {
@@ -778,7 +785,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		if (_buildCountJSONObject == null) {
 			try {
 				_buildCountJSONObject = JenkinsResultsParserUtil.toJSONObject(
-					getURL() + "api/json?tree=jobs[name,allBuilds[timestamp]]");
+					URLBuilderUtil.buildURL(
+						getURL() + "api/json", "tree",
+						"jobs[name,allBuilds[timestamp]]"));
 			}
 			catch (IOException ioException) {
 				return 0;
@@ -856,7 +865,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 			try {
 				if (!isBlacklisted()) {
 					JenkinsResultsParserUtil.toJSONObject(
-						getURL() + "/api/json?tree=mode", false, 1, 1, 1000);
+						URLBuilderUtil.buildURL(
+							getURL() + "/api/json", "tree", "mode"),
+						false, 1, 1, 1000);
 
 					_available = true;
 				}
@@ -976,11 +987,12 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 		try {
 			computerAPIJSONObject = JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					getURL(), "/computer/api/json?tree=computer",
-					"[assignedLabels[name],displayName,",
-					"executors[currentExecutable[url]],idle,offline,",
-					"offlineCauseReason]"),
+				URLBuilderUtil.buildURL(
+					getURL() + "/computer/api/json", "tree",
+					JenkinsResultsParserUtil.combine(
+						"computer[assignedLabels[name],displayName,",
+						"executors[currentExecutable[url]],idle,offline,",
+						"offlineCauseReason]")),
 				false, 5000);
 		}
 		catch (Exception exception) {
@@ -1356,13 +1368,17 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 
 			@Override
 			public JSONArray execute() {
-				String url = JenkinsResultsParserUtil.getLocalURL(
-					JenkinsResultsParserUtil.combine(
-						String.valueOf(getURL()), "/job/", jobName,
-						"/api/json?tree=allBuilds[actions[parameters",
-						"[name,value]],queueId,timestamp,url]{",
-						String.valueOf(page * 100), ",",
-						String.valueOf((page + 1) * 100), "}"));
+				String tree = JenkinsResultsParserUtil.combine(
+					"allBuilds[actions[parameters[name,value]],queueId,",
+					"timestamp,url]{", String.valueOf(page * 100), ",",
+					String.valueOf((page + 1) * 100), "}");
+
+				String url = URLBuilderUtil.buildURL(
+					JenkinsResultsParserUtil.getLocalURL(
+						JenkinsResultsParserUtil.combine(
+							String.valueOf(getURL()), "/job/", jobName,
+							"/api/json")),
+					"tree", tree);
 
 				try {
 					JSONObject jsonObject =
@@ -1593,7 +1609,9 @@ public class JenkinsMaster implements JenkinsNode<JenkinsMaster> {
 		try {
 			JSONObject topLevelBuildsJSONObject =
 				JenkinsResultsParserUtil.toJSONObject(
-					getURL() + "/view/Top%20Level/api/json?tree=jobs[name]");
+					URLBuilderUtil.buildURL(
+						getURL() + "/view/Top%20Level/api/json", "tree",
+						"jobs[name]"));
 
 			JSONArray jobsJSONArray = topLevelBuildsJSONObject.optJSONArray(
 				"jobs");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1512,8 +1512,6 @@ public class JenkinsResultsParserUtil {
 	public static String getCacheFileKey(String urlString, String postContent) {
 		String key = URLBuilderUtil.normalizeURL(urlString);
 
-		key.replace("//", "/");
-
 		if (!isNullOrEmpty(postContent)) {
 			key += postContent;
 		}
@@ -2861,7 +2859,7 @@ public class JenkinsResultsParserUtil {
 		String baseInvocationURL, String blacklist, int invokedBatchSize,
 		String jobName) {
 
-		Map<String, String> parameters = new LinkedHashMap<>();
+		Map<String, String> parameters = new HashMap<>();
 
 		parameters.put("baseInvocationURL", baseInvocationURL);
 
@@ -3651,7 +3649,7 @@ public class JenkinsResultsParserUtil {
 		String jenkinsJobURL, Map<String, String> buildParameters,
 		int timeout) {
 
-		Map<String, String> parameters = new LinkedHashMap<>();
+		Map<String, String> parameters = new HashMap<>();
 
 		if (buildParameters != null) {
 			for (Map.Entry<String, String> buildParameter :
@@ -5872,7 +5870,7 @@ public class JenkinsResultsParserUtil {
 				return;
 			}
 
-			Map<String, String> parameters = new LinkedHashMap<>();
+			Map<String, String> parameters = new HashMap<>();
 
 			parameters.put("client_id", _clientId);
 			parameters.put("client_secret", _clientSecret);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -33,7 +33,6 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.Socket;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLDecoder;
@@ -386,10 +385,6 @@ public class JenkinsResultsParserUtil {
 		return jsonObject;
 	}
 
-	public static URL createURL(String url) throws Exception {
-		return encode(new URL(url));
-	}
-
 	public static String decode(String url)
 		throws UnsupportedEncodingException {
 
@@ -503,24 +498,40 @@ public class JenkinsResultsParserUtil {
 			});
 	}
 
-	public static String encode(String url)
-		throws MalformedURLException, URISyntaxException {
+	/**
+	 * Returns the part encoded the way this repository has always encoded a
+	 * single path part, for a caller that has to keep matching a string
+	 * written earlier.
+	 *
+	 * <p>
+	 * This is form encoding with four characters put back afterwards, so an
+	 * exclamation mark, a percent sign, and a plus sign survive unencoded. The
+	 * percent sign and the plus sign are the reason the spelling is wrong in
+	 * principle. It is kept only because a cloud storage object key and a
+	 * GitHub label are matched against a name that was already written with
+	 * this spelling, and changing it would stop the match without reporting
+	 * anything.
+	 * </p>
+	 *
+	 * <p>
+	 * Do not use this to build a URL. Use
+	 * {@link URLBuilderUtil#buildURL(String, String, String)} instead.
+	 * </p>
+	 */
+	public static String encodeLegacyURLPart(String part) {
+		try {
+			part = URLEncoder.encode(part, StandardCharsets.UTF_8.name());
 
-		URL encodedURL = encode(new URL(url));
+			part = part.replaceAll("\\+", "%20");
 
-		return encodedURL.toExternalForm();
-	}
+			part = part.replaceAll("%21", "!");
+			part = part.replaceAll("%25", "%");
 
-	public static URL encode(URL url)
-		throws MalformedURLException, URISyntaxException {
-
-		URI uri = new URI(
-			url.getProtocol(), url.getUserInfo(), url.getHost(), url.getPort(),
-			url.getPath(), url.getQuery(), url.getRef());
-
-		String uriASCIIString = uri.toASCIIString();
-
-		return new URL(uriASCIIString.replace("#", "%23"));
+			return part.replaceAll("%2B", "+");
+		}
+		catch (UnsupportedEncodingException unsupportedEncodingException) {
+			throw new RuntimeException(unsupportedEncodingException);
+		}
 	}
 
 	public static String encodeURLParameterPart(String parameterPart) {
@@ -918,79 +929,6 @@ public class JenkinsResultsParserUtil {
 		json = json.replaceAll("\u00BB", "&raquo;");
 
 		return json;
-	}
-
-	public static String fixURL(String urlString) {
-		URL url = null;
-
-		try {
-			url = new URL(urlString);
-		}
-		catch (MalformedURLException malformedURLException) {
-			try {
-				urlString = URLEncoder.encode(
-					urlString, StandardCharsets.UTF_8.name());
-
-				urlString = urlString.replaceAll("\\+", "%20");
-
-				urlString = urlString.replaceAll("%21", "!");
-				urlString = urlString.replaceAll("%25", "%");
-				urlString = urlString.replaceAll("%2B", "+");
-
-				return urlString;
-			}
-			catch (UnsupportedEncodingException unsupportedEncodingException) {
-				throw new RuntimeException(unsupportedEncodingException);
-			}
-		}
-
-		if (!urlString.contains("?")) {
-			return urlString;
-		}
-
-		StringBuilder sb = new StringBuilder(
-			urlString.replaceAll("(.*\\?).*", "$1"));
-
-		String queryString = url.getQuery();
-
-		if ((queryString == null) || queryString.isEmpty()) {
-			return sb.toString();
-		}
-
-		Matcher matcher = _urlQueryStringPattern.matcher(url.getQuery());
-
-		while (matcher.find()) {
-			sb.append(matcher.group(1));
-			sb.append("=");
-
-			try {
-				String queryParameterValue = matcher.group(2);
-
-				queryParameterValue = URLEncoder.encode(
-					queryParameterValue, StandardCharsets.UTF_8.name());
-
-				queryParameterValue = queryParameterValue.replaceAll(
-					"\\+", "%20");
-
-				queryParameterValue = queryParameterValue.replaceAll(
-					"%21", "!");
-				queryParameterValue = queryParameterValue.replaceAll(
-					"%25", "%");
-				queryParameterValue = queryParameterValue.replaceAll(
-					"%2B", "+");
-
-				sb.append(queryParameterValue);
-			}
-			catch (UnsupportedEncodingException unsupportedEncodingException) {
-				throw new RuntimeException(unsupportedEncodingException);
-			}
-
-			if (!matcher.hitEnd()) {
-				sb.append("&");
-			}
-		}
-
-		return sb.toString();
 	}
 
 	public static List<Build> flatten(List<Build> builds) {
@@ -1572,7 +1510,7 @@ public class JenkinsResultsParserUtil {
 	}
 
 	public static String getCacheFileKey(String urlString, String postContent) {
-		String key = fixURL(urlString);
+		String key = URLBuilderUtil.normalizeURL(urlString);
 
 		key.replace("//", "/");
 
@@ -6987,8 +6925,6 @@ public class JenkinsResultsParserUtil {
 		"test-1-(\\d+)");
 	private static final Set<String> _timeStamps = new HashSet<>();
 	private static Set<String> _topLevelJobNames;
-	private static final Pattern _urlQueryStringPattern = Pattern.compile(
-		"\\&??(\\w++)=([^\\&]*)");
 	private static final File _userHomeDir = new File(
 		System.getProperty("user.home"));
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -657,7 +657,7 @@ public class JenkinsResultsParserUtil {
 					combine("http://", jenkinsMasterName, "/script"));
 			}
 
-			URL urlObject = new URL(fixURL(url));
+			URL urlObject = new URL(URLBuilderUtil.normalizeURL(url));
 
 			HttpURLConnection httpURLConnection =
 				(HttpURLConnection)urlObject.openConnection();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -678,7 +678,8 @@ public class JenkinsResultsParserUtil {
 			try (OutputStream outputStream =
 					httpURLConnection.getOutputStream()) {
 
-				String post = "script=" + URLEncoder.encode(script, "UTF-8");
+				String post = URLBuilderUtil.buildFormContent(
+					Collections.singletonMap("script", script));
 
 				outputStream.write(post.getBytes("UTF-8"));
 
@@ -3712,31 +3713,23 @@ public class JenkinsResultsParserUtil {
 		String jenkinsJobURL, Map<String, String> buildParameters,
 		int timeout) {
 
-		StringBuilder sb = new StringBuilder();
+		Map<String, String> parameters = new LinkedHashMap<>();
+
+		if (buildParameters != null) {
+			for (Map.Entry<String, String> buildParameter :
+					buildParameters.entrySet()) {
+
+				String value = buildParameter.getValue();
+
+				if (isNullOrEmpty(value)) {
+					continue;
+				}
+
+				parameters.put(buildParameter.getKey(), value);
+			}
+		}
 
 		try {
-			if (buildParameters != null) {
-				for (Map.Entry<String, String> buildParameter :
-						buildParameters.entrySet()) {
-
-					String value = buildParameter.getValue();
-
-					if (isNullOrEmpty(value)) {
-						continue;
-					}
-
-					sb.append(
-						URLEncoder.encode(buildParameter.getKey(), "UTF-8"));
-					sb.append("=");
-					sb.append(URLEncoder.encode(value, "UTF-8"));
-					sb.append("&");
-				}
-			}
-
-			if (sb.length() > 0) {
-				sb.deleteCharAt(sb.length() - 1);
-			}
-
 			Map<String, String> requestHeaders = new HashMap<>();
 
 			requestHeaders.put(
@@ -3745,7 +3738,8 @@ public class JenkinsResultsParserUtil {
 			return getJenkinsBuildQueueId(
 				UrlReader.getResponseHeader(
 					"Location", getJenkinsHTTPAuthorization(),
-					HttpRequestMethod.POST, sb.toString(), requestHeaders,
+					HttpRequestMethod.POST,
+					URLBuilderUtil.buildFormContent(parameters), requestHeaders,
 					timeout, combine(jenkinsJobURL, "/buildWithParameters")));
 		}
 		catch (IOException ioException) {
@@ -5940,16 +5934,16 @@ public class JenkinsResultsParserUtil {
 				return;
 			}
 
-			StringBuilder sb = new StringBuilder();
+			Map<String, String> parameters = new LinkedHashMap<>();
 
-			sb.append("grant_type=client_credentials&client_id=");
-			sb.append(_clientId);
-			sb.append("&client_secret=");
-			sb.append(_clientSecret);
+			parameters.put("client_id", _clientId);
+			parameters.put("client_secret", _clientSecret);
+			parameters.put("grant_type", "client_credentials");
 
 			try {
 				JSONObject jsonObject = toJSONObject(
-					String.valueOf(_tokenURL), sb.toString());
+					String.valueOf(_tokenURL),
+					URLBuilderUtil.buildFormContent(parameters));
 
 				_token = jsonObject.getString("access_token");
 				_tokenExpirationDate = new Date(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -500,23 +500,11 @@ public class JenkinsResultsParserUtil {
 
 	/**
 	 * Returns the part encoded the way this repository has always encoded a
-	 * single path part, for a caller that has to keep matching a string
-	 * written earlier.
-	 *
-	 * <p>
-	 * This is form encoding with four characters put back afterwards, so an
-	 * exclamation mark, a percent sign, and a plus sign survive unencoded. The
-	 * percent sign and the plus sign are the reason the spelling is wrong in
-	 * principle. It is kept only because a cloud storage object key and a
-	 * GitHub label are matched against a name that was already written with
-	 * this spelling, and changing it would stop the match without reporting
-	 * anything.
-	 * </p>
-	 *
-	 * <p>
-	 * Do not use this to build a URL. Use
-	 * {@link URLBuilderUtil#buildURL(String, String, String)} instead.
-	 * </p>
+	 * single path part. This is form encoding with four characters put back
+	 * afterwards, so a percent sign and a plus sign survive unencoded, which
+	 * is wrong in principle and kept only because a cloud storage object key
+	 * is matched against a name already written this way. Do not build a URL
+	 * with this. Use {@link URLBuilderUtil#buildURL(String, String, String)}.
 	 */
 	public static String encodeLegacyURLPart(String part) {
 		try {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -2922,29 +2922,28 @@ public class JenkinsResultsParserUtil {
 		String baseInvocationURL, String blacklist, int invokedBatchSize,
 		String jobName) {
 
-		StringBuilder sb = new StringBuilder();
+		Map<String, String> parameters = new LinkedHashMap<>();
 
-		sb.append(getJenkinsLoadBalancerURL());
-		sb.append("?baseInvocationURL=");
-		sb.append(baseInvocationURL);
+		parameters.put("baseInvocationURL", baseInvocationURL);
 
 		if (blacklist != null) {
-			sb.append("&blacklist=");
-			sb.append(blacklist);
+			parameters.put("blacklist", blacklist);
 		}
 
 		if (invokedBatchSize > 0) {
-			sb.append("&invokedJobBatchSize=");
-			sb.append(invokedBatchSize);
+			parameters.put(
+				"invokedJobBatchSize", String.valueOf(invokedBatchSize));
 		}
 
 		if (!isNullOrEmpty(jobName)) {
-			sb.append("&jobName=");
-			sb.append(fixURL(jobName));
+			parameters.put("jobName", jobName);
 		}
 
+		String loadBalancerURL = URLBuilderUtil.buildURL(
+			getJenkinsLoadBalancerURL(), parameters);
+
 		try {
-			JSONObject jsonObject = toJSONObject(sb.toString(), false);
+			JSONObject jsonObject = toJSONObject(loadBalancerURL, false);
 
 			return jsonObject.getString("mostAvailableMasterURL");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -1308,8 +1308,9 @@ public class JenkinsResultsParserUtil {
 		}
 
 		if (jsonObject == null) {
-			String buildParametersURL = getLocalURL(
-				buildURL + "api/json?tree=actions[parameters[name,value]]");
+			String buildParametersURL = URLBuilderUtil.buildURL(
+				getLocalURL(buildURL + "api/json"), "tree",
+				"actions[parameters[name,value]]");
 
 			try {
 				jsonObject = toJSONObject(buildParametersURL);
@@ -2330,7 +2331,9 @@ public class JenkinsResultsParserUtil {
 	public static String getJenkinsBuildResult(String buildURL) {
 		try {
 			JSONObject jsonObject = toJSONObject(
-				buildURL + "/api/json?tree=result", false);
+				URLBuilderUtil.buildURL(
+					buildURL + "/api/json", "tree", "result"),
+				false);
 
 			if (!jsonObject.has("result") || jsonObject.isNull("result")) {
 				return null;
@@ -4120,8 +4123,10 @@ public class JenkinsResultsParserUtil {
 
 				try {
 					topLevelBuildsJSONObject = toJSONObject(
-						jenkinsMaster.getRemoteURL() +
-							"/view/Top%20Level/api/json?tree=jobs[name]");
+						URLBuilderUtil.buildURL(
+							jenkinsMaster.getRemoteURL() +
+								"/view/Top%20Level/api/json",
+							"tree", "jobs[name]"));
 				}
 				catch (IOException ioException) {
 					throw new RuntimeException(ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -26,7 +26,7 @@ public class JenkinsStopBuildUtil {
 			JenkinsMaster jenkinsMaster, long queueId)
 		throws Exception {
 
-		String normalizedURL = JenkinsResultsParserUtil.fixURL(
+		String normalizedURL = URLBuilderUtil.normalizeURL(
 			JenkinsResultsParserUtil.getLocalURL(jenkinsMaster.getURL()));
 
 		URL urlObject = new URL(
@@ -122,7 +122,7 @@ public class JenkinsStopBuildUtil {
 	}
 
 	private static void _stopBuild(String buildURL) throws Exception {
-		String normalizedBuildURL = JenkinsResultsParserUtil.fixURL(
+		String normalizedBuildURL = URLBuilderUtil.normalizeURL(
 			JenkinsResultsParserUtil.getLocalURL(buildURL));
 
 		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -124,7 +124,9 @@ public class JenkinsStopBuildUtil {
 			JenkinsResultsParserUtil.getLocalURL(buildURL));
 
 		JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-			normalizedBuildURL + "/api/json?tree=result", false);
+			URLBuilderUtil.buildURL(
+				normalizedBuildURL + "/api/json", "tree", "result"),
+			false);
 
 		if (jsonObject.has("result") && jsonObject.isNull("result")) {
 			URL urlObject = new URL(normalizedBuildURL + "/stop");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsStopBuildUtil.java
@@ -30,7 +30,9 @@ public class JenkinsStopBuildUtil {
 			JenkinsResultsParserUtil.getLocalURL(jenkinsMaster.getURL()));
 
 		URL urlObject = new URL(
-			normalizedURL + "/queue/cancelItem?id=" + queueId);
+			URLBuilderUtil.buildURL(
+				normalizedURL + "/queue/cancelItem", "id",
+				String.valueOf(queueId)));
 
 		HttpURLConnection httpConnection =
 			(HttpURLConnection)urlObject.openConnection();

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobReport.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JobReport.java
@@ -82,9 +82,10 @@ public class JobReport {
 
 		try {
 			JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-				JenkinsResultsParserUtil.combine(
-					String.valueOf(getJobURL()), "/api/json?tree=",
-					"builds[actions[parameters[name,value]],*]"));
+				URLBuilderUtil.buildURL(
+					JenkinsResultsParserUtil.combine(
+						String.valueOf(getJobURL()), "/api/json"),
+					"tree", "builds[actions[parameters[name,value]],*]"));
 
 			if (jsonObject == null) {
 				return _topLevelBuildReports;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralGitSubrepositoryUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/MergeCentralGitSubrepositoryUtil.java
@@ -288,9 +288,11 @@ public class MergeCentralGitSubrepositoryUtil {
 			int page = 1;
 
 			while (page < 10) {
-				String url = JenkinsResultsParserUtil.getGitHubAPIURL(
-					centralGitWorkingDirectory.getGitRepositoryName(),
-					receiverUserName, "pulls?page=" + String.valueOf(page));
+				String url = URLBuilderUtil.buildURL(
+					JenkinsResultsParserUtil.getGitHubAPIURL(
+						centralGitWorkingDirectory.getGitRepositoryName(),
+						receiverUserName, "pulls"),
+					"page", String.valueOf(page));
 
 				JSONArray jsonArray = JenkinsResultsParserUtil.toJSONArray(url);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
@@ -301,25 +302,21 @@ public class PoshiReleasePortalTopLevelBuildRunner
 						upstreamBranchName));
 			}
 
-			Map<String, String> parameters = new HashMap<>();
+			Iterator<Map.Entry<String, String>> iterator =
+				invocationParameters.entrySet(
+				).iterator();
 
-			for (Map.Entry<String, String> invocationParameter :
-					invocationParameters.entrySet()) {
-
-				String invocationParameterValue =
-					invocationParameter.getValue();
+			while (iterator.hasNext()) {
+				Map.Entry<String, String> invocationParameter = iterator.next();
 
 				if (JenkinsResultsParserUtil.isNullOrEmpty(
-						invocationParameterValue)) {
+						invocationParameter.getValue())) {
 
-					continue;
+					iterator.remove();
 				}
-
-				parameters.put(
-					invocationParameter.getKey(), invocationParameterValue);
 			}
 
-			return URLBuilderUtil.buildURL(jobURL, parameters);
+			return URLBuilderUtil.buildURL(jobURL, invocationParameters);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PoshiReleasePortalTopLevelBuildRunner.java
@@ -238,15 +238,11 @@ public class PoshiReleasePortalTopLevelBuildRunner
 	private String _getBuildInvocationURL(
 		String jobName, Map.Entry<GitWorkingDirectory, PullRequest> entry) {
 
-		StringBuilder sb = new StringBuilder();
-
 		BuildData buildData = getBuildData();
 
-		sb.append(getBaseInvocationURL(buildData.getCohortName(), jobName));
-
-		sb.append("/job/");
-		sb.append(jobName);
-		sb.append("/buildWithParameters?");
+		String jobURL = JenkinsResultsParserUtil.combine(
+			getBaseInvocationURL(buildData.getCohortName(), jobName), "/job/",
+			jobName, "/buildWithParameters");
 
 		try {
 			Map<String, String> invocationParameters = new HashMap<>();
@@ -305,6 +301,8 @@ public class PoshiReleasePortalTopLevelBuildRunner
 						upstreamBranchName));
 			}
 
+			Map<String, String> parameters = new HashMap<>();
+
 			for (Map.Entry<String, String> invocationParameter :
 					invocationParameters.entrySet()) {
 
@@ -317,25 +315,15 @@ public class PoshiReleasePortalTopLevelBuildRunner
 					continue;
 				}
 
-				sb.append(
-					JenkinsResultsParserUtil.encodeURLParameterPart(
-						invocationParameter.getKey()));
-				sb.append("=");
-				sb.append(
-					JenkinsResultsParserUtil.encodeURLParameterPart(
-						invocationParameterValue));
-				sb.append("&");
+				parameters.put(
+					invocationParameter.getKey(), invocationParameterValue);
 			}
+
+			return URLBuilderUtil.buildURL(jobURL, parameters);
 		}
 		catch (IOException ioException) {
 			throw new RuntimeException(ioException);
 		}
-
-		if (sb.charAt(sb.length() - 1) == '&') {
-			sb.deleteCharAt(sb.length() - 1);
-		}
-
-		return sb.toString();
 	}
 
 	private File _getBuildTestGradleFile(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -1003,7 +1003,7 @@ public class PullRequest {
 
 		String path = JenkinsResultsParserUtil.combine(
 			"issues/", getNumber(), "/labels/",
-			JenkinsResultsParserUtil.fixURL(labelName));
+			JenkinsResultsParserUtil.encodeLegacyURLPart(labelName));
 
 		String gitHubAPIURL = JenkinsResultsParserUtil.getGitHubAPIURL(
 			getGitHubRemoteGitRepositoryName(), getOwnerUsername(), path);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -1354,12 +1354,10 @@ public class PullRequest {
 	}
 
 	private void _initCommits() {
-		String commitsURL = _jsonObject.getString("commits_url");
-
 		_gitHubRemoteGitCommits = new ArrayList<>();
 
-		String pageCommitsURL = URLBuilderUtil.buildURL(
-			commitsURL, "per_page", "100");
+		String commitsURL = URLBuilderUtil.buildURL(
+			_jsonObject.getString("commits_url"), "per_page", "100");
 
 		try {
 			for (int pageNumber = 1;
@@ -1370,8 +1368,7 @@ public class PullRequest {
 				JSONArray commitsJSONArray =
 					JenkinsResultsParserUtil.toJSONArray(
 						URLBuilderUtil.buildURL(
-							pageCommitsURL, "page",
-							String.valueOf(pageNumber)));
+							commitsURL, "page", String.valueOf(pageNumber)));
 
 				if (commitsJSONArray.length() == 0) {
 					break;

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -348,9 +348,11 @@ public class PullRequest {
 
 		_comments = new ArrayList<>();
 
-		String gitHubAPIURL = JenkinsResultsParserUtil.getGitHubAPIURL(
-			getGitHubRemoteGitRepositoryName(), getOwnerUsername(),
-			"issues/" + getNumber() + "/comments?per_page=100&page=");
+		String gitHubAPIURL = URLBuilderUtil.buildURL(
+			JenkinsResultsParserUtil.getGitHubAPIURL(
+				getGitHubRemoteGitRepositoryName(), getOwnerUsername(),
+				"issues/" + getNumber() + "/comments"),
+			"per_page", "100");
 
 		for (int pageNumber = 1;
 			 pageNumber <=
@@ -360,7 +362,9 @@ public class PullRequest {
 			try {
 				JSONArray commentJSONArray =
 					JenkinsResultsParserUtil.toJSONArray(
-						gitHubAPIURL + pageNumber, false);
+						URLBuilderUtil.appendParameter(
+							gitHubAPIURL, "page", String.valueOf(pageNumber)),
+						false);
 
 				if (commentJSONArray.length() == 0) {
 					break;
@@ -1360,10 +1364,13 @@ public class PullRequest {
 					 JenkinsResultsParserUtil.PAGES_GITHUB_API_PAGES_SIZE_MAX;
 				 pageNumber++) {
 
+				String pageCommitsURL = URLBuilderUtil.buildURL(
+					commitsURL, "per_page", "100");
+
 				JSONArray commitsJSONArray =
 					JenkinsResultsParserUtil.toJSONArray(
-						JenkinsResultsParserUtil.combine(
-							commitsURL, "?per_page=100&page=",
+						URLBuilderUtil.appendParameter(
+							pageCommitsURL, "page",
 							String.valueOf(pageNumber)));
 
 				if (commitsJSONArray.length() == 0) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/PullRequest.java
@@ -362,7 +362,7 @@ public class PullRequest {
 			try {
 				JSONArray commentJSONArray =
 					JenkinsResultsParserUtil.toJSONArray(
-						URLBuilderUtil.appendParameter(
+						URLBuilderUtil.buildURL(
 							gitHubAPIURL, "page", String.valueOf(pageNumber)),
 						false);
 
@@ -1358,18 +1358,18 @@ public class PullRequest {
 
 		_gitHubRemoteGitCommits = new ArrayList<>();
 
+		String pageCommitsURL = URLBuilderUtil.buildURL(
+			commitsURL, "per_page", "100");
+
 		try {
 			for (int pageNumber = 1;
 				 pageNumber <=
 					 JenkinsResultsParserUtil.PAGES_GITHUB_API_PAGES_SIZE_MAX;
 				 pageNumber++) {
 
-				String pageCommitsURL = URLBuilderUtil.buildURL(
-					commitsURL, "per_page", "100");
-
 				JSONArray commitsJSONArray =
 					JenkinsResultsParserUtil.toJSONArray(
-						URLBuilderUtil.appendParameter(
+						URLBuilderUtil.buildURL(
 							pageCommitsURL, "page",
 							String.valueOf(pageNumber)));
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/QAWebsitesControllerBuildRunner.java
@@ -319,8 +319,10 @@ public class QAWebsitesControllerBuildRunner
 
 			try {
 				JSONObject jsonObject = JenkinsResultsParserUtil.toJSONObject(
-					JenkinsResultsParserUtil.getLocalURL(
-						buildURL + "/api/json?tree=result"));
+					URLBuilderUtil.buildURL(
+						JenkinsResultsParserUtil.getLocalURL(
+							buildURL + "/api/json"),
+						"tree", "result"));
 
 				Object result = jsonObject.get("result");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/TopLevelBuildRunner.java
@@ -320,31 +320,12 @@ public abstract class TopLevelBuildRunner<T extends TopLevelBuildData>
 		invocationParameters.put(
 			"PARENT_BUILD_URL", _topLevelBuild.getBuildURL());
 
-		StringBuilder sb = new StringBuilder();
+		String jobURL = JenkinsResultsParserUtil.combine(
+			getBaseInvocationURL(cohortName, jobName), "/job/", jobName,
+			"/buildWithParameters");
 
-		sb.append(getBaseInvocationURL(cohortName, jobName));
-		sb.append("/job/");
-		sb.append(jobName);
-		sb.append("/buildWithParameters?");
-
-		for (Map.Entry<String, String> invocationParameter :
-				invocationParameters.entrySet()) {
-
-			sb.append(
-				JenkinsResultsParserUtil.encodeURLParameterPart(
-					invocationParameter.getKey()));
-			sb.append("=");
-			sb.append(
-				JenkinsResultsParserUtil.encodeURLParameterPart(
-					invocationParameter.getValue()));
-			sb.append("&");
-		}
-
-		if (sb.charAt(sb.length() - 1) == '&') {
-			sb.deleteCharAt(sb.length() - 1);
-		}
-
-		_topLevelBuild.addDownstreamBuilds(sb.toString());
+		_topLevelBuild.addDownstreamBuilds(
+			URLBuilderUtil.buildURL(jobURL, invocationParameters));
 	}
 
 	private void _invokeDownstreamBuild(BuildData buildData) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
@@ -23,30 +23,19 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 
 /**
- * Builds and decomposes URLs so that a value is encoded exactly once, at the
- * point the URL is assembled, and is held decoded everywhere else.
- *
- * <p>
- * This is the only class in the module that references
- * <code>org.apache.http</code>. Confining the dependency here keeps a
- * <code>URIBuilder</code> from being held as a field or a static, which
- * matters because downstream work runs concurrently through
- * <code>ParallelExecutor</code> and <code>URIBuilder</code> is mutable and not
- * thread safe. Every method below constructs its own instance and discards it.
- * </p>
+ * Builds and decomposes URLs so that a value is encoded exactly once, when the
+ * URL is assembled, and is held decoded everywhere else. This is the only
+ * class here that references <code>org.apache.http</code>, which keeps a
+ * mutable <code>URIBuilder</code> from being shared across the threads
+ * <code>ParallelExecutor</code> runs.
  *
  * @author Calum Ragan
  */
 public class URLBuilderUtil {
 
 	/**
-	 * Returns the parameters encoded as an
-	 * <code>application/x-www-form-urlencoded</code> request body.
-	 *
-	 * <p>
-	 * This is for a POST body, not a URL. A body carries no leading question
-	 * mark.
-	 * </p>
+	 * Returns an <code>application/x-www-form-urlencoded</code> request body,
+	 * which unlike a URL carries no leading question mark.
 	 */
 	public static String buildFormContent(Map<String, String> parameters) {
 		if ((parameters == null) || parameters.isEmpty()) {
@@ -67,33 +56,13 @@ public class URLBuilderUtil {
 	}
 
 	/**
-	 * Returns the base URL with the parameters appended as a query string,
-	 * each name and value percent encoded exactly once.
-	 *
-	 * <p>
-	 * The base URL's path is passed through untouched, so a job name such as
-	 * <code>test-portal-acceptance-pullrequest(master)</code> is preserved
-	 * verbatim. A base URL that is not a legal URI reference is repaired with
-	 * {@link #normalizeURL(String)} first, which percent encodes an octet that
-	 * is illegal where it sits, so a raw space in a path becomes
-	 * <code>%20</code>.
-	 * </p>
-	 *
-	 * <p>
-	 * The base URL may already carry a query string and a fragment. Parameters
-	 * are inserted before the fragment, and a pre-existing query string is
-	 * re-emitted in canonical form, so a space already spelled
-	 * <code>%20</code> comes back as <code>+</code>. The two are equivalent
-	 * under form decoding but are not byte identical.
-	 * </p>
-	 *
-	 * <p>
-	 * Parameters are emitted in ascending name order so that the same map
-	 * always produces the same URL. A null value emits a valueless parameter,
-	 * an empty value emits a name followed by an equals sign, and both round
-	 * trip through {@link #parseQueryString(String)}. A null or empty map
-	 * returns the base URL unchanged, without a trailing question mark.
-	 * </p>
+	 * Returns the base URL with the parameters appended, each name and value
+	 * percent encoded exactly once and emitted in ascending name order so that
+	 * the same map always produces the same URL. The path is passed through
+	 * untouched. A base URL that is not a legal URI reference is repaired with
+	 * {@link #normalizeURL(String)} first, and one that already carries a
+	 * query string has it re-emitted in canonical form. A null or empty map
+	 * returns the base URL unchanged, with no trailing question mark.
 	 */
 	public static String buildURL(
 		String baseURL, Map<String, String> parameters) {
@@ -116,8 +85,6 @@ public class URLBuilderUtil {
 	}
 
 	/**
-	 * Returns the base URL with a single query parameter appended.
-	 *
 	 * @see #buildURL(String, Map)
 	 */
 	public static String buildURL(String baseURL, String name, String value) {
@@ -131,28 +98,12 @@ public class URLBuilderUtil {
 	}
 
 	/**
-	 * Returns a URL that <code>java.net.URL</code> and
-	 * <code>HttpURLConnection</code> can use verbatim.
-	 *
-	 * <p>
-	 * A URL that already parses as a legal URI reference is returned
-	 * unchanged. Nothing is re-encoded, no escape is reversed, and the
-	 * fragment is preserved, so every URL built by this class passes through
-	 * untouched.
-	 * </p>
-	 *
-	 * <p>
-	 * Otherwise the URL arrived already assembled from an external source and
-	 * carries an octet that is illegal where it sits, most often a raw space,
-	 * a raw square bracket, or a bare percent sign. Each illegal octet is
-	 * percent encoded in place. A valid escape is left alone, so the method is
-	 * idempotent.
-	 * </p>
-	 *
-	 * <p>
-	 * A URL that cannot be repaired is returned unchanged after a warning.
-	 * This method never throws.
-	 * </p>
+	 * Returns a URL that <code>HttpURLConnection</code> can use verbatim. One
+	 * that already parses as a legal URI reference is returned unchanged, so
+	 * nothing this class builds is altered. Otherwise each octet that is
+	 * illegal where it sits is percent encoded in place, leaving a valid
+	 * escape alone, which makes this idempotent. A URL that cannot be repaired
+	 * is returned unchanged after a warning. This never throws.
 	 */
 	public static String normalizeURL(String url) {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(url) ||
@@ -209,18 +160,10 @@ public class URLBuilderUtil {
 	}
 
 	/**
-	 * Returns the query string decomposed into decoded name and value pairs.
-	 *
-	 * <p>
-	 * A parameter that carries an invalid escape is kept as raw text rather
-	 * than failing, matching how a query string that was never encoded is
-	 * still readable.
-	 * </p>
-	 *
-	 * <p>
-	 * When a name repeats, the first value wins and the duplicate is reported.
-	 * A valueless parameter yields a null value.
-	 * </p>
+	 * Returns the query string decomposed into decoded name and value pairs. A
+	 * parameter carrying an invalid escape is kept as raw text rather than
+	 * failing. When a name repeats the first value wins and the duplicate is
+	 * reported, and a valueless parameter yields a null value.
 	 */
 	public static Map<String, String> parseQueryString(String queryString) {
 		if (JenkinsResultsParserUtil.isNullOrEmpty(queryString)) {
@@ -277,9 +220,9 @@ public class URLBuilderUtil {
 	}
 
 	private static void _escapeCodePoint(StringBuilder sb, int codePoint) {
-		String value = new String(Character.toChars(codePoint));
+		String codePointString = new String(Character.toChars(codePoint));
 
-		byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+		byte[] bytes = codePointString.getBytes(StandardCharsets.UTF_8);
 
 		for (byte b : bytes) {
 			int octet = b & 0xff;
@@ -292,17 +235,9 @@ public class URLBuilderUtil {
 
 	/**
 	 * Returns <code>true</code> when the URL carries a raw square bracket in
-	 * its query string or fragment.
-	 *
-	 * <p>
-	 * RFC 3986 does not permit a square bracket outside the authority, but
-	 * <code>URI</code> accepts one in a query string and in a fragment.
-	 * Escaping it is therefore the conformant reading, and it is also what
-	 * this repository has always put on the wire for a Jenkins
-	 * <code>tree</code> expression, so a converted call site is not observable
-	 * by a server. This is the one place where a URL that <code>URI</code>
-	 * accepts is still treated as needing repair.
-	 * </p>
+	 * its query string or fragment. RFC 3986 does not permit one outside the
+	 * authority but <code>URI</code> accepts it there, so this is the one case
+	 * where a URL <code>URI</code> accepts still needs repair.
 	 */
 	private static boolean _hasRawSquareBracket(String url) {
 		int index = url.indexOf('?');
@@ -362,15 +297,9 @@ public class URLBuilderUtil {
 	}
 
 	/**
-	 * Returns a builder over the URL, repairing the URL first when it does not
-	 * parse.
-	 *
-	 * <p>
-	 * A URL assembled outside this class may carry a raw space or square
-	 * bracket, most often from a test name or a cloud storage object key.
-	 * Repairing it keeps appending a parameter to such a URL from throwing
-	 * where plain concatenation would have quietly succeeded.
-	 * </p>
+	 * Returns a builder over the URL, repairing it first when it does not
+	 * parse, so that a URL assembled elsewhere with a raw space does not throw
+	 * where plain concatenation used to succeed.
 	 */
 	private static URIBuilder _newURIBuilder(String url) {
 		try {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
@@ -419,13 +419,31 @@ public class URLBuilderUtil {
 		}
 	}
 
+	/**
+	 * Returns a builder over the URL, repairing the URL first when it does not
+	 * parse.
+	 *
+	 * <p>
+	 * A URL assembled outside this class may carry a raw space or square
+	 * bracket, most often from a test name or a cloud storage object key.
+	 * Repairing it keeps appending a parameter to such a URL from throwing
+	 * where plain concatenation would have quietly succeeded.
+	 * </p>
+	 */
 	private static URIBuilder _newURIBuilder(String url) {
 		try {
 			return new URIBuilder(url);
 		}
-		catch (URISyntaxException uriSyntaxException) {
-			throw new RuntimeException(
-				"Unable to parse the URL " + url, uriSyntaxException);
+		catch (URISyntaxException uriSyntaxException1) {
+			String normalizedURL = normalizeURL(url);
+
+			try {
+				return new URIBuilder(normalizedURL);
+			}
+			catch (URISyntaxException uriSyntaxException2) {
+				throw new RuntimeException(
+					"Unable to parse the URL " + url, uriSyntaxException2);
+			}
 		}
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
@@ -40,55 +40,6 @@ import org.apache.http.message.BasicNameValuePair;
 public class URLBuilderUtil {
 
 	/**
-	 * Returns the URL with one more query parameter appended.
-	 *
-	 * <p>
-	 * The URL may already carry a query string and a fragment. The parameter
-	 * is inserted before the fragment. Any pre-existing query string is
-	 * re-emitted in canonical form, so a space already spelled
-	 * <code>%20</code> comes back as <code>+</code>. The two are equivalent
-	 * under form decoding but are not byte identical.
-	 * </p>
-	 */
-	public static String appendParameter(
-		String url, String name, String value) {
-
-		Map<String, String> parameters = new LinkedHashMap<>();
-
-		parameters.put(name, value);
-
-		return appendParameters(url, parameters);
-	}
-
-	/**
-	 * Returns the URL with the parameters appended, in ascending name order.
-	 *
-	 * <p>
-	 * Returns the URL unchanged when the parameters are null or empty, without
-	 * appending a trailing question mark.
-	 * </p>
-	 */
-	public static String appendParameters(
-		String url, Map<String, String> parameters) {
-
-		if ((parameters == null) || parameters.isEmpty()) {
-			return url;
-		}
-
-		URIBuilder uriBuilder = _newURIBuilder(url);
-
-		Map<String, String> sortedParameters = new TreeMap<>(parameters);
-
-		for (Map.Entry<String, String> entry : sortedParameters.entrySet()) {
-			uriBuilder.addParameter(entry.getKey(), entry.getValue());
-		}
-
-		URI uri = _build(uriBuilder, url);
-
-		return uri.toString();
-	}
-
-	/**
 	 * Returns the parameters encoded as an
 	 * <code>application/x-www-form-urlencoded</code> request body.
 	 *
@@ -120,55 +71,63 @@ public class URLBuilderUtil {
 	 * each name and value percent encoded exactly once.
 	 *
 	 * <p>
-	 * The base URL must already be a legal URI reference. Its path is passed
-	 * through untouched, so a job name such as
+	 * The base URL's path is passed through untouched, so a job name such as
 	 * <code>test-portal-acceptance-pullrequest(master)</code> is preserved
-	 * verbatim.
+	 * verbatim. A base URL that is not a legal URI reference is repaired with
+	 * {@link #normalizeURL(String)} first, which percent encodes an octet that
+	 * is illegal where it sits, so a raw space in a path becomes
+	 * <code>%20</code>.
+	 * </p>
+	 *
+	 * <p>
+	 * The base URL may already carry a query string and a fragment. Parameters
+	 * are inserted before the fragment, and a pre-existing query string is
+	 * re-emitted in canonical form, so a space already spelled
+	 * <code>%20</code> comes back as <code>+</code>. The two are equivalent
+	 * under form decoding but are not byte identical.
 	 * </p>
 	 *
 	 * <p>
 	 * Parameters are emitted in ascending name order so that the same map
 	 * always produces the same URL. A null value emits a valueless parameter,
 	 * an empty value emits a name followed by an equals sign, and both round
-	 * trip through {@link #parseQueryString(String)}.
+	 * trip through {@link #parseQueryString(String)}. A null or empty map
+	 * returns the base URL unchanged, without a trailing question mark.
 	 * </p>
 	 */
 	public static String buildURL(
 		String baseURL, Map<String, String> parameters) {
 
-		return appendParameters(baseURL, parameters);
+		if ((parameters == null) || parameters.isEmpty()) {
+			return baseURL;
+		}
+
+		URIBuilder uriBuilder = _newURIBuilder(baseURL);
+
+		Map<String, String> sortedParameters = new TreeMap<>(parameters);
+
+		for (Map.Entry<String, String> entry : sortedParameters.entrySet()) {
+			uriBuilder.addParameter(entry.getKey(), entry.getValue());
+		}
+
+		URI uri = _build(uriBuilder, baseURL);
+
+		return uri.toString();
 	}
 
 	/**
 	 * Returns the base URL with a single query parameter appended.
+	 *
+	 * @see #buildURL(String, Map)
 	 */
 	public static String buildURL(String baseURL, String name, String value) {
-		return appendParameter(baseURL, name, value);
-	}
+		URIBuilder uriBuilder = _newURIBuilder(baseURL);
 
-	/**
-	 * Returns the URL's query string decomposed into decoded name and value
-	 * pairs.
-	 *
-	 * <p>
-	 * Falls back to {@link #parseQueryString(String)} when the URL is not a
-	 * legal URI reference, so a URL carrying an invalid escape is decomposed
-	 * rather than rejected.
-	 * </p>
-	 */
-	public static Map<String, String> getParameters(String url) {
-		if (JenkinsResultsParserUtil.isNullOrEmpty(url)) {
-			return Collections.emptyMap();
-		}
+		uriBuilder.addParameter(name, value);
 
-		try {
-			URIBuilder uriBuilder = new URIBuilder(url);
+		URI uri = _build(uriBuilder, baseURL);
 
-			return _toMap(uriBuilder.getQueryParams());
-		}
-		catch (URISyntaxException uriSyntaxException) {
-			return parseQueryString(_getQueryString(url));
-		}
+		return uri.toString();
 	}
 
 	/**
@@ -290,64 +249,45 @@ public class URLBuilderUtil {
 		while (i < value.length()) {
 			char c = value.charAt(i);
 
-			if (c == '%') {
-				if (_isEscapeSequence(value, i)) {
-					sb.append(value, i, i + 3);
+			if ((c == '%') && _isEscapeSequence(value, i)) {
+				sb.append(value, i, i + 3);
 
-					i = i + 3;
-				}
-				else {
-					sb.append("%25");
-
-					i++;
-				}
-
-				continue;
+				i = i + 3;
 			}
-
-			if (_isLegalCharacter(c, legalCharacters)) {
+			else if (_isLegalCharacter(c, legalCharacters)) {
 				sb.append(c);
 
 				i++;
-
-				continue;
 			}
+			else {
 
-			int codePoint = value.codePointAt(i);
+				// A percent sign is in neither legal character set, so a bare
+				// one that starts no escape sequence lands here and is encoded
+				// as %25
 
-			_escapeCodePoint(sb, new String(Character.toChars(codePoint)));
+				int codePoint = value.codePointAt(i);
 
-			i = i + Character.charCount(codePoint);
+				_escapeCodePoint(sb, codePoint);
+
+				i = i + Character.charCount(codePoint);
+			}
 		}
 
 		return sb.toString();
 	}
 
-	private static void _escapeCodePoint(StringBuilder sb, String value) {
+	private static void _escapeCodePoint(StringBuilder sb, int codePoint) {
+		String value = new String(Character.toChars(codePoint));
+
 		byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
 
 		for (byte b : bytes) {
+			int octet = b & 0xff;
+
 			sb.append("%");
-			sb.append(String.format("%02X", b & 0xff));
+			sb.append(_HEXADECIMAL_CHARACTERS.charAt(octet >> 4));
+			sb.append(_HEXADECIMAL_CHARACTERS.charAt(octet & 0x0f));
 		}
-	}
-
-	private static String _getQueryString(String url) {
-		int index = url.indexOf('?');
-
-		if (index == -1) {
-			return null;
-		}
-
-		String queryString = url.substring(index + 1);
-
-		index = queryString.indexOf('#');
-
-		if (index != -1) {
-			queryString = queryString.substring(0, index);
-		}
-
-		return queryString;
 	}
 
 	/**
@@ -355,11 +295,13 @@ public class URLBuilderUtil {
 	 * its query string or fragment.
 	 *
 	 * <p>
-	 * <code>URI</code> tolerates a square bracket there, deviating
-	 * from RFC 3986 to stay compatible with the Jenkins <code>tree</code>
-	 * syntax. Escaping it anyway keeps the bytes on the wire identical to what
-	 * this repository has always sent, so converting a call site to
-	 * {@link #buildURL(String, String, String)} is not observable by a server.
+	 * RFC 3986 does not permit a square bracket outside the authority, but
+	 * <code>URI</code> accepts one in a query string and in a fragment.
+	 * Escaping it is therefore the conformant reading, and it is also what
+	 * this repository has always put on the wire for a Jenkins
+	 * <code>tree</code> expression, so a converted call site is not observable
+	 * by a server. This is the one place where a URL that <code>URI</code>
+	 * accepts is still treated as needing repair.
 	 * </p>
 	 */
 	private static boolean _hasRawSquareBracket(String url) {
@@ -450,10 +392,6 @@ public class URLBuilderUtil {
 	private static Map<String, String> _toMap(
 		List<NameValuePair> nameValuePairs) {
 
-		if (nameValuePairs.isEmpty()) {
-			return Collections.emptyMap();
-		}
-
 		Map<String, String> parameters = new LinkedHashMap<>(
 			nameValuePairs.size());
 
@@ -479,6 +417,7 @@ public class URLBuilderUtil {
 
 	private static final String _LEGAL_PATH_CHARACTERS = "-._~!$&'()*+,;=:@/";
 
-	private static final String _LEGAL_QUERY_CHARACTERS = "-._~!$&'()*+,;=:@/?";
+	private static final String _LEGAL_QUERY_CHARACTERS =
+		_LEGAL_PATH_CHARACTERS + "?";
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
@@ -203,11 +203,6 @@ public class URLBuilderUtil {
 				i++;
 			}
 			else {
-
-				// A percent sign is in neither legal character set, so a bare
-				// one that starts no escape sequence lands here and is encoded
-				// as %25
-
 				int codePoint = value.codePointAt(i);
 
 				_escapeCodePoint(sb, codePoint);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLBuilderUtil.java
@@ -1,0 +1,466 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
+
+/**
+ * Builds and decomposes URLs so that a value is encoded exactly once, at the
+ * point the URL is assembled, and is held decoded everywhere else.
+ *
+ * <p>
+ * This is the only class in the module that references
+ * <code>org.apache.http</code>. Confining the dependency here keeps a
+ * <code>URIBuilder</code> from being held as a field or a static, which
+ * matters because downstream work runs concurrently through
+ * <code>ParallelExecutor</code> and <code>URIBuilder</code> is mutable and not
+ * thread safe. Every method below constructs its own instance and discards it.
+ * </p>
+ *
+ * @author Calum Ragan
+ */
+public class URLBuilderUtil {
+
+	/**
+	 * Returns the URL with one more query parameter appended.
+	 *
+	 * <p>
+	 * The URL may already carry a query string and a fragment. The parameter
+	 * is inserted before the fragment. Any pre-existing query string is
+	 * re-emitted in canonical form, so a space already spelled
+	 * <code>%20</code> comes back as <code>+</code>. The two are equivalent
+	 * under form decoding but are not byte identical.
+	 * </p>
+	 */
+	public static String appendParameter(
+		String url, String name, String value) {
+
+		Map<String, String> parameters = new LinkedHashMap<>();
+
+		parameters.put(name, value);
+
+		return appendParameters(url, parameters);
+	}
+
+	/**
+	 * Returns the URL with the parameters appended, in ascending name order.
+	 *
+	 * <p>
+	 * Returns the URL unchanged when the parameters are null or empty, without
+	 * appending a trailing question mark.
+	 * </p>
+	 */
+	public static String appendParameters(
+		String url, Map<String, String> parameters) {
+
+		if ((parameters == null) || parameters.isEmpty()) {
+			return url;
+		}
+
+		URIBuilder uriBuilder = _newURIBuilder(url);
+
+		Map<String, String> sortedParameters = new TreeMap<>(parameters);
+
+		for (Map.Entry<String, String> entry : sortedParameters.entrySet()) {
+			uriBuilder.addParameter(entry.getKey(), entry.getValue());
+		}
+
+		URI uri = _build(uriBuilder, url);
+
+		return uri.toString();
+	}
+
+	/**
+	 * Returns the parameters encoded as an
+	 * <code>application/x-www-form-urlencoded</code> request body.
+	 *
+	 * <p>
+	 * This is for a POST body, not a URL. A body carries no leading question
+	 * mark.
+	 * </p>
+	 */
+	public static String buildFormContent(Map<String, String> parameters) {
+		if ((parameters == null) || parameters.isEmpty()) {
+			return "";
+		}
+
+		Map<String, String> sortedParameters = new TreeMap<>(parameters);
+
+		List<NameValuePair> nameValuePairs = new ArrayList<>(
+			sortedParameters.size());
+
+		for (Map.Entry<String, String> entry : sortedParameters.entrySet()) {
+			nameValuePairs.add(
+				new BasicNameValuePair(entry.getKey(), entry.getValue()));
+		}
+
+		return URLEncodedUtils.format(nameValuePairs, StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Returns the base URL with the parameters appended as a query string,
+	 * each name and value percent encoded exactly once.
+	 *
+	 * <p>
+	 * The base URL must already be a legal URI reference. Its path is passed
+	 * through untouched, so a job name such as
+	 * <code>test-portal-acceptance-pullrequest(master)</code> is preserved
+	 * verbatim.
+	 * </p>
+	 *
+	 * <p>
+	 * Parameters are emitted in ascending name order so that the same map
+	 * always produces the same URL. A null value emits a valueless parameter,
+	 * an empty value emits a name followed by an equals sign, and both round
+	 * trip through {@link #parseQueryString(String)}.
+	 * </p>
+	 */
+	public static String buildURL(
+		String baseURL, Map<String, String> parameters) {
+
+		return appendParameters(baseURL, parameters);
+	}
+
+	/**
+	 * Returns the base URL with a single query parameter appended.
+	 */
+	public static String buildURL(String baseURL, String name, String value) {
+		return appendParameter(baseURL, name, value);
+	}
+
+	/**
+	 * Returns the URL's query string decomposed into decoded name and value
+	 * pairs.
+	 *
+	 * <p>
+	 * Falls back to {@link #parseQueryString(String)} when the URL is not a
+	 * legal URI reference, so a URL carrying an invalid escape is decomposed
+	 * rather than rejected.
+	 * </p>
+	 */
+	public static Map<String, String> getParameters(String url) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(url)) {
+			return Collections.emptyMap();
+		}
+
+		try {
+			URIBuilder uriBuilder = new URIBuilder(url);
+
+			return _toMap(uriBuilder.getQueryParams());
+		}
+		catch (URISyntaxException uriSyntaxException) {
+			return parseQueryString(_getQueryString(url));
+		}
+	}
+
+	/**
+	 * Returns a URL that <code>java.net.URL</code> and
+	 * <code>HttpURLConnection</code> can use verbatim.
+	 *
+	 * <p>
+	 * A URL that already parses as a legal URI reference is returned
+	 * unchanged. Nothing is re-encoded, no escape is reversed, and the
+	 * fragment is preserved, so every URL built by this class passes through
+	 * untouched.
+	 * </p>
+	 *
+	 * <p>
+	 * Otherwise the URL arrived already assembled from an external source and
+	 * carries an octet that is illegal where it sits, most often a raw space,
+	 * a raw square bracket, or a bare percent sign. Each illegal octet is
+	 * percent encoded in place. A valid escape is left alone, so the method is
+	 * idempotent.
+	 * </p>
+	 *
+	 * <p>
+	 * A URL that cannot be repaired is returned unchanged after a warning.
+	 * This method never throws.
+	 * </p>
+	 */
+	public static String normalizeURL(String url) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(url) ||
+			(_isLegalURI(url) && !_hasRawSquareBracket(url))) {
+
+			return url;
+		}
+
+		String remainder = url;
+
+		String fragment = null;
+
+		int index = remainder.indexOf('#');
+
+		if (index != -1) {
+			fragment = remainder.substring(index + 1);
+
+			remainder = remainder.substring(0, index);
+		}
+
+		String queryString = null;
+
+		index = remainder.indexOf('?');
+
+		if (index != -1) {
+			queryString = remainder.substring(index + 1);
+
+			remainder = remainder.substring(0, index);
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(_escape(remainder, _LEGAL_PATH_CHARACTERS));
+
+		if (queryString != null) {
+			sb.append("?");
+			sb.append(_escape(queryString, _LEGAL_QUERY_CHARACTERS));
+		}
+
+		if (fragment != null) {
+			sb.append("#");
+			sb.append(_escape(fragment, _LEGAL_QUERY_CHARACTERS));
+		}
+
+		String normalizedURL = sb.toString();
+
+		if (!_isLegalURI(normalizedURL)) {
+			System.out.println("WARNING: Unable to normalize the URL " + url);
+
+			return url;
+		}
+
+		return normalizedURL;
+	}
+
+	/**
+	 * Returns the query string decomposed into decoded name and value pairs.
+	 *
+	 * <p>
+	 * A parameter that carries an invalid escape is kept as raw text rather
+	 * than failing, matching how a query string that was never encoded is
+	 * still readable.
+	 * </p>
+	 *
+	 * <p>
+	 * When a name repeats, the first value wins and the duplicate is reported.
+	 * A valueless parameter yields a null value.
+	 * </p>
+	 */
+	public static Map<String, String> parseQueryString(String queryString) {
+		if (JenkinsResultsParserUtil.isNullOrEmpty(queryString)) {
+			return Collections.emptyMap();
+		}
+
+		return _toMap(
+			URLEncodedUtils.parse(queryString, StandardCharsets.UTF_8));
+	}
+
+	private static URI _build(URIBuilder uriBuilder, String url) {
+		try {
+			return uriBuilder.build();
+		}
+		catch (URISyntaxException uriSyntaxException) {
+			throw new RuntimeException(
+				"Unable to build the URL " + url, uriSyntaxException);
+		}
+	}
+
+	private static String _escape(String value, String legalCharacters) {
+		StringBuilder sb = new StringBuilder(value.length());
+
+		int i = 0;
+
+		while (i < value.length()) {
+			char c = value.charAt(i);
+
+			if (c == '%') {
+				if (_isEscapeSequence(value, i)) {
+					sb.append(value, i, i + 3);
+
+					i = i + 3;
+				}
+				else {
+					sb.append("%25");
+
+					i++;
+				}
+
+				continue;
+			}
+
+			if (_isLegalCharacter(c, legalCharacters)) {
+				sb.append(c);
+
+				i++;
+
+				continue;
+			}
+
+			int codePoint = value.codePointAt(i);
+
+			_escapeCodePoint(sb, new String(Character.toChars(codePoint)));
+
+			i = i + Character.charCount(codePoint);
+		}
+
+		return sb.toString();
+	}
+
+	private static void _escapeCodePoint(StringBuilder sb, String value) {
+		byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+
+		for (byte b : bytes) {
+			sb.append("%");
+			sb.append(String.format("%02X", b & 0xff));
+		}
+	}
+
+	private static String _getQueryString(String url) {
+		int index = url.indexOf('?');
+
+		if (index == -1) {
+			return null;
+		}
+
+		String queryString = url.substring(index + 1);
+
+		index = queryString.indexOf('#');
+
+		if (index != -1) {
+			queryString = queryString.substring(0, index);
+		}
+
+		return queryString;
+	}
+
+	/**
+	 * Returns <code>true</code> when the URL carries a raw square bracket in
+	 * its query string or fragment.
+	 *
+	 * <p>
+	 * <code>URI</code> tolerates a square bracket there, deviating
+	 * from RFC 3986 to stay compatible with the Jenkins <code>tree</code>
+	 * syntax. Escaping it anyway keeps the bytes on the wire identical to what
+	 * this repository has always sent, so converting a call site to
+	 * {@link #buildURL(String, String, String)} is not observable by a server.
+	 * </p>
+	 */
+	private static boolean _hasRawSquareBracket(String url) {
+		int index = url.indexOf('?');
+
+		if (index == -1) {
+			return false;
+		}
+
+		String remainder = url.substring(index + 1);
+
+		if ((remainder.indexOf('[') != -1) || (remainder.indexOf(']') != -1)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isEscapeSequence(String value, int index) {
+		if ((index + 2) >= value.length()) {
+			return false;
+		}
+
+		for (int i = index + 1; i <= (index + 2); i++) {
+			char c = value.charAt(i);
+
+			if (_HEXADECIMAL_CHARACTERS.indexOf(c) == -1) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static boolean _isLegalCharacter(char c, String legalCharacters) {
+		if (((c >= 'A') && (c <= 'Z')) || ((c >= 'a') && (c <= 'z')) ||
+			((c >= '0') && (c <= '9'))) {
+
+			return true;
+		}
+
+		if (legalCharacters.indexOf(c) != -1) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static boolean _isLegalURI(String url) {
+		try {
+			new URI(url);
+
+			return true;
+		}
+		catch (URISyntaxException uriSyntaxException) {
+			return false;
+		}
+	}
+
+	private static URIBuilder _newURIBuilder(String url) {
+		try {
+			return new URIBuilder(url);
+		}
+		catch (URISyntaxException uriSyntaxException) {
+			throw new RuntimeException(
+				"Unable to parse the URL " + url, uriSyntaxException);
+		}
+	}
+
+	private static Map<String, String> _toMap(
+		List<NameValuePair> nameValuePairs) {
+
+		if (nameValuePairs.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		Map<String, String> parameters = new LinkedHashMap<>(
+			nameValuePairs.size());
+
+		for (NameValuePair nameValuePair : nameValuePairs) {
+			String name = nameValuePair.getName();
+
+			if (parameters.containsKey(name)) {
+				System.out.println(
+					"WARNING: Ignoring the repeated query string parameter " +
+						name);
+
+				continue;
+			}
+
+			parameters.put(name, nameValuePair.getValue());
+		}
+
+		return parameters;
+	}
+
+	private static final String _HEXADECIMAL_CHARACTERS =
+		"0123456789ABCDEFabcdef";
+
+	private static final String _LEGAL_PATH_CHARACTERS = "-._~!$&'()*+,;=:@/";
+
+	private static final String _LEGAL_QUERY_CHARACTERS = "-._~!$&'()*+,;=:@/?";
+
+}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLCompareUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/URLCompareUtil.java
@@ -7,12 +7,8 @@ package com.liferay.jenkins.results.parser;
 
 import java.net.URL;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author Peter Yoo
@@ -45,21 +41,7 @@ public class URLCompareUtil {
 	}
 
 	private static Map<String, String> _getQueryMap(URL url) {
-		String query = url.getQuery();
-
-		if (query == null) {
-			return Collections.emptyMap();
-		}
-
-		Map<String, String> queryMap = new HashMap<>();
-
-		Matcher matcher = _queryPattern.matcher(query);
-
-		while (matcher.find()) {
-			queryMap.put(matcher.group("name"), matcher.group("value"));
-		}
-
-		return queryMap;
+		return URLBuilderUtil.parseQueryString(url.getQuery());
 	}
 
 	private static String _normalizePath(String path) {
@@ -67,8 +49,5 @@ public class URLCompareUtil {
 
 		return normalizedPath.replaceAll("/*$", "");
 	}
-
-	private static final Pattern _queryPattern = Pattern.compile(
-		"(&|\\A)?(?<name>[^=]+)=(?<value>[^&]+)");
 
 }

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/UrlReader.java
@@ -85,7 +85,7 @@ public class UrlReader {
 			Map<String, String> requestHeaders, int timeout, String url)
 		throws IOException {
 
-		URL urlObject = new URL(JenkinsResultsParserUtil.fixURL(url));
+		URL urlObject = new URL(URLBuilderUtil.normalizeURL(url));
 
 		HttpURLConnection httpURLConnection =
 			(HttpURLConnection)urlObject.openConnection();
@@ -160,7 +160,7 @@ public class UrlReader {
 			}
 		}
 
-		url = JenkinsResultsParserUtil.fixURL(url);
+		url = URLBuilderUtil.normalizeURL(url);
 
 		if (url.startsWith("file:")) {
 			url = JenkinsResultsParserUtil.fixFileURL(url);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudBucket.java
@@ -16,6 +16,7 @@ import com.google.cloud.storage.StorageOptions;
 
 import com.liferay.jenkins.results.parser.Environment;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -316,9 +317,11 @@ public class ScanCodeCloudBucket {
 	public URL getURL() {
 		try {
 			return new URL(
-				JenkinsResultsParserUtil.combine(
-					"https://console.cloud.google.com/storage/browser/",
-					getName(), "?authuser=0"));
+				URLBuilderUtil.buildURL(
+					JenkinsResultsParserUtil.combine(
+						"https://console.cloud.google.com/storage/browser/",
+						getName()),
+					"authuser", "0"));
 		}
 		catch (MalformedURLException malformedURLException) {
 			throw new RuntimeException(malformedURLException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudObject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/scancode/ScanCodeCloudObject.java
@@ -8,6 +8,7 @@ package com.liferay.jenkins.results.parser.scancode;
 import com.google.cloud.storage.Blob;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -40,7 +41,7 @@ public class ScanCodeCloudObject {
 	}
 
 	public String getURLString() {
-		return JenkinsResultsParserUtil.fixURL(String.valueOf(_url));
+		return URLBuilderUtil.normalizeURL(String.valueOf(_url));
 	}
 
 	public String getValue() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseStandaloneBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseStandaloneBuildTestrayCaseResult.java
@@ -11,6 +11,7 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.Job;
 import com.liferay.jenkins.results.parser.TestSuiteJob;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -243,7 +244,15 @@ public abstract class BaseStandaloneBuildTestrayCaseResult
 					attachmentFileElement.addAttribute(
 						"name", testrayAttachment.getName());
 					attachmentFileElement.addAttribute(
-						"url", testrayAttachment.getURL() + "?authuser=0");
+						"url",
+						URLBuilderUtil.buildURL(
+							String.valueOf(testrayAttachment.getURL()),
+							"authuser", "0"));
+
+					// The value attribute carries a cloud storage object key
+					// rather than a URL, and Testray matches it against the
+					// key the uploader wrote, so it is left concatenated
+
 					attachmentFileElement.addAttribute(
 						"value", testrayAttachment.getKey() + "?authuser=0");
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseStandaloneBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/BaseStandaloneBuildTestrayCaseResult.java
@@ -249,10 +249,6 @@ public abstract class BaseStandaloneBuildTestrayCaseResult
 							String.valueOf(testrayAttachment.getURL()),
 							"authuser", "0"));
 
-					// The value attribute carries a cloud storage object key
-					// rather than a URL, and Testray matches it against the
-					// key the uploader wrote, so it is left concatenated
-
 					attachmentFileElement.addAttribute(
 						"value", testrayAttachment.getKey() + "?authuser=0");
 				}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/DXPCloudClientTestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/DXPCloudClientTestrayImporter.java
@@ -252,10 +252,6 @@ public class DXPCloudClientTestrayImporter {
 					_testrayCloudBucket.getTestrayCloudBaseURL(), "/", key),
 				"authuser", "0"));
 
-		// The value attribute carries a cloud storage object key rather than a
-		// URL, and Testray matches it against the key the uploader wrote, so
-		// it is left concatenated
-
 		attachmentElement.addAttribute("value", key + "?authuser=0");
 
 		return attachmentElement;
@@ -406,10 +402,6 @@ public class DXPCloudClientTestrayImporter {
 					JenkinsResultsParserUtil.combine(
 						_testrayCloudBucket.getTestrayCloudBaseURL(), "/", key),
 					"authuser", "0"));
-
-			// The value attribute carries a cloud storage object key rather
-			// than a URL, and Testray matches it against the key the uploader
-			// wrote, so it is left concatenated
 
 			attachmentElement.addAttribute("value", key + "?authuser=0");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/DXPCloudClientTestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/DXPCloudClientTestrayImporter.java
@@ -8,6 +8,7 @@ package com.liferay.jenkins.results.parser.testray;
 import com.liferay.jenkins.results.parser.Dom4JUtil;
 import com.liferay.jenkins.results.parser.Environment;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -246,9 +247,15 @@ public class DXPCloudClientTestrayImporter {
 		attachmentElement.addAttribute("name", "Poshi Log");
 		attachmentElement.addAttribute(
 			"url",
-			JenkinsResultsParserUtil.combine(
-				_testrayCloudBucket.getTestrayCloudBaseURL(), "/", key,
-				"?authuser=0"));
+			URLBuilderUtil.buildURL(
+				JenkinsResultsParserUtil.combine(
+					_testrayCloudBucket.getTestrayCloudBaseURL(), "/", key),
+				"authuser", "0"));
+
+		// The value attribute carries a cloud storage object key rather than a
+		// URL, and Testray matches it against the key the uploader wrote, so
+		// it is left concatenated
+
 		attachmentElement.addAttribute("value", key + "?authuser=0");
 
 		return attachmentElement;
@@ -395,9 +402,15 @@ public class DXPCloudClientTestrayImporter {
 
 			attachmentElement.addAttribute(
 				"url",
-				JenkinsResultsParserUtil.combine(
-					_testrayCloudBucket.getTestrayCloudBaseURL(), "/", key,
-					"?authuser=0"));
+				URLBuilderUtil.buildURL(
+					JenkinsResultsParserUtil.combine(
+						_testrayCloudBucket.getTestrayCloudBaseURL(), "/", key),
+					"authuser", "0"));
+
+			// The value attribute carries a cloud storage object key rather
+			// than a URL, and Testray matches it against the key the uploader
+			// wrote, so it is left concatenated
+
 			attachmentElement.addAttribute("value", key + "?authuser=0");
 		}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/FunctionalBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/FunctionalBatchBuildTestrayCaseResult.java
@@ -197,7 +197,8 @@ public class FunctionalBatchBuildTestrayCaseResult
 		return getTestrayAttachment(
 			getBuildReport(), "Poshi Console",
 			JenkinsResultsParserUtil.combine(
-				getAxisName(), "/", JenkinsResultsParserUtil.fixURL(name),
+				getAxisName(), "/",
+				JenkinsResultsParserUtil.encodeLegacyURLPart(name),
 				"/console.txt.gz"));
 	}
 
@@ -213,7 +214,8 @@ public class FunctionalBatchBuildTestrayCaseResult
 		return getTestrayAttachment(
 			getBuildReport(), "Poshi Report",
 			JenkinsResultsParserUtil.combine(
-				getAxisName(), "/", JenkinsResultsParserUtil.fixURL(name),
+				getAxisName(), "/",
+				JenkinsResultsParserUtil.encodeLegacyURLPart(name),
 				"/index.html.gz"));
 	}
 
@@ -229,7 +231,8 @@ public class FunctionalBatchBuildTestrayCaseResult
 		return getTestrayAttachment(
 			getBuildReport(), "Poshi Summary",
 			JenkinsResultsParserUtil.combine(
-				getAxisName(), "/", JenkinsResultsParserUtil.fixURL(name),
+				getAxisName(), "/",
+				JenkinsResultsParserUtil.encodeLegacyURLPart(name),
 				"/summary.html.gz"));
 	}
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/PlaywrightBatchBuildTestrayCaseResult.java
@@ -11,6 +11,7 @@ import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.TestClassReport;
 import com.liferay.jenkins.results.parser.TestReport;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 import com.liferay.jenkins.results.parser.test.clazz.PlaywrightJUnitTestClass;
 import com.liferay.jenkins.results.parser.test.clazz.PlaywrightTestClassMethod;
 import com.liferay.jenkins.results.parser.test.clazz.TestClass;
@@ -288,7 +289,9 @@ public class PlaywrightBatchBuildTestrayCaseResult
 
 		try {
 			URL url = new URL(
-				"https://playwright.liferay.com/?trace=" + traceZipURLPath);
+				URLBuilderUtil.buildURL(
+					"https://playwright.liferay.com/", "trace",
+					traceZipURLPath));
 
 			return new DefaultTestrayAttachment(
 				this, "Trace Viewer", traceZipURLPath, url);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/RunTestrayFactor.java
@@ -7,10 +7,9 @@ package com.liferay.jenkins.results.parser.testray;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.Retryable;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.io.IOException;
-
-import java.net.URLEncoder;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -81,8 +80,8 @@ public class RunTestrayFactor extends BaseTestrayFactor {
 				try {
 					JSONObject existingJSONObject = new JSONObject(
 						testrayServer.requestGet(
-							"/o/c/factors?filter=" +
-								URLEncoder.encode(filterString, "UTF-8")));
+							URLBuilderUtil.buildURL(
+								"/o/c/factors", "filter", filterString)));
 
 					JSONArray existingItemsJSONArray =
 						existingJSONObject.optJSONArray("items");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudBucket.java
@@ -16,6 +16,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.liferay.jenkins.results.parser.Environment;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.ParallelExecutor;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -376,9 +377,11 @@ public class TestrayCloudBucket {
 	public URL getURL() {
 		try {
 			return new URL(
-				JenkinsResultsParserUtil.combine(
-					"https://console.cloud.google.com/storage/browser/",
-					getName(), "?authuser=0"));
+				URLBuilderUtil.buildURL(
+					JenkinsResultsParserUtil.combine(
+						"https://console.cloud.google.com/storage/browser/",
+						getName()),
+					"authuser", "0"));
 		}
 		catch (MalformedURLException malformedURLException) {
 			throw new RuntimeException(malformedURLException);

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudObject.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayCloudObject.java
@@ -8,6 +8,7 @@ package com.liferay.jenkins.results.parser.testray;
 import com.google.cloud.storage.Blob;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.io.File;
 
@@ -58,7 +59,7 @@ public class TestrayCloudObject {
 	}
 
 	public String getURLString() {
-		return JenkinsResultsParserUtil.fixURL(String.valueOf(_url));
+		return URLBuilderUtil.normalizeURL(String.valueOf(_url));
 	}
 
 	public String getValue() {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayFactor.java
@@ -6,10 +6,9 @@
 package com.liferay.jenkins.results.parser.testray;
 
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.io.IOException;
-
-import java.net.URLEncoder;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -113,8 +112,8 @@ public interface TestrayFactor {
 			try {
 				JSONObject jsonObject = new JSONObject(
 					_testrayServer.requestGet(
-						"/o/c/factorcategories?filter=" +
-							URLEncoder.encode(filterString, "UTF-8")));
+						URLBuilderUtil.buildURL(
+							"/o/c/factorcategories", "filter", filterString)));
 
 				JSONArray itemsJSONArray = jsonObject.optJSONArray("items");
 
@@ -243,8 +242,8 @@ public interface TestrayFactor {
 			try {
 				JSONObject jsonObject = new JSONObject(
 					_testrayServer.requestGet(
-						"/o/c/factoroptions?filter=" +
-							URLEncoder.encode(filterString, "UTF-8")));
+						URLBuilderUtil.buildURL(
+							"/o/c/factoroptions", "filter", filterString)));
 
 				JSONArray itemsJSONArray = jsonObject.optJSONArray("items");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -26,6 +26,7 @@ import com.liferay.jenkins.results.parser.QAWebsitesGitRepositoryJob;
 import com.liferay.jenkins.results.parser.QAWebsitesWorkspaceGitRepository;
 import com.liferay.jenkins.results.parser.TestSuiteJob;
 import com.liferay.jenkins.results.parser.TopLevelBuildReport;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 import com.liferay.jenkins.results.parser.Workspace;
 import com.liferay.jenkins.results.parser.WorkspaceGitRepository;
 import com.liferay.jenkins.results.parser.job.property.JobProperty;
@@ -394,8 +395,9 @@ public class TestrayImporter {
 				"jenkins-report.html.gz");
 
 		if (testrayAttachmentURL != null) {
-			sb.append(testrayAttachmentURL);
-			sb.append("?authuser=0");
+			sb.append(
+				URLBuilderUtil.buildURL(
+					String.valueOf(testrayAttachmentURL), "authuser", "0"));
 		}
 		else {
 			sb.append(_topLevelBuildReport.getJenkinsReportURL());
@@ -1487,7 +1489,15 @@ public class TestrayImporter {
 			attachmentFileElement.addAttribute(
 				"name", testrayAttachment.getName());
 			attachmentFileElement.addAttribute(
-				"url", testrayAttachment.getURL() + "?authuser=0");
+				"url",
+				URLBuilderUtil.buildURL(
+					String.valueOf(testrayAttachment.getURL()), "authuser",
+					"0"));
+
+			// The value attribute carries a cloud storage object key rather
+			// than a URL, and Testray matches it against the key the uploader
+			// wrote, so it is left concatenated
+
 			attachmentFileElement.addAttribute(
 				"value", testrayAttachment.getKey() + "?authuser=0");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayImporter.java
@@ -1494,10 +1494,6 @@ public class TestrayImporter {
 					String.valueOf(testrayAttachment.getURL()), "authuser",
 					"0"));
 
-			// The value attribute carries a cloud storage object key rather
-			// than a URL, and Testray matches it against the key the uploader
-			// wrote, so it is left concatenated
-
 			attachmentFileElement.addAttribute(
 				"value", testrayAttachment.getKey() + "?authuser=0");
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
@@ -468,8 +468,7 @@ public class TestrayRun {
 
 			JSONObject responseJSONObject = new JSONObject(
 				testrayServer.requestGet(
-					URLBuilderUtil.appendParameter(
-						urlPath, "pageSize", "100")));
+					URLBuilderUtil.buildURL(urlPath, "pageSize", "100")));
 
 			JSONArray itemsJSONArray = responseJSONObject.optJSONArray("items");
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/testray/TestrayRun.java
@@ -8,10 +8,9 @@ package com.liferay.jenkins.results.parser.testray;
 import com.liferay.jenkins.results.parser.Dom4JUtil;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
 import com.liferay.jenkins.results.parser.Retryable;
+import com.liferay.jenkins.results.parser.URLBuilderUtil;
 
 import java.io.IOException;
-
-import java.net.URLEncoder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -193,8 +192,8 @@ public class TestrayRun {
 				try {
 					JSONObject existingJSONObject = new JSONObject(
 						testrayServer.requestGet(
-							"/o/c/runs?filter=" +
-								URLEncoder.encode(filterString, "UTF-8")));
+							URLBuilderUtil.buildURL(
+								"/o/c/runs", "filter", filterString)));
 
 					JSONArray existingItemsJSONArray =
 						existingJSONObject.optJSONArray("items");
@@ -417,8 +416,8 @@ public class TestrayRun {
 
 			JSONObject jsonObject = new JSONObject(
 				testrayServer.requestGet(
-					"/o/c/runs?filter=" +
-						URLEncoder.encode(filterString, "UTF-8")));
+					URLBuilderUtil.buildURL(
+						"/o/c/runs", "filter", filterString)));
 
 			return jsonObject.optInt("totalCount") + 1;
 		}
@@ -464,12 +463,13 @@ public class TestrayRun {
 		try {
 			TestrayServer testrayServer = _testrayBuild.getTestrayServer();
 
+			String urlPath = URLBuilderUtil.buildURL(
+				"/o/c/factors", "filter", filterString);
+
 			JSONObject responseJSONObject = new JSONObject(
 				testrayServer.requestGet(
-					JenkinsResultsParserUtil.combine(
-						"/o/c/factors?filter=",
-						URLEncoder.encode(filterString, "UTF-8"),
-						"&pageSize=100")));
+					URLBuilderUtil.appendParameter(
+						urlPath, "pageSize", "100")));
 
 			JSONArray itemsJSONArray = responseJSONObject.optJSONArray("items");
 

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -71,6 +71,34 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 	}
 
 	@Test
+	public void testGetInvocationURL() throws Exception {
+		Map<String, String> parameters = _newParameters(
+			"PORTAL BUILD NOTES", "encoded name", "PORTAL_BATCH_TEST_SELECTOR",
+			"PortalSmoke#Smoke", "PORTAL_BUILD_NOTES", "100% pass",
+			"PORTAL_QUERY", "a=b", "PORTAL_UPSTREAM", "a+b",
+			"TESTRAY_PROJECT_NAME", "AWS & CI");
+
+		Map<String, String> roundTrippedParameters = _setInvocationURL(
+			_getInvocationURL(parameters));
+
+		for (Map.Entry<String, String> entry : parameters.entrySet()) {
+			Assert.assertEquals(
+				entry.getValue(), roundTrippedParameters.get(entry.getKey()));
+		}
+	}
+
+	@Test
+	public void testGetInvocationURLWithoutParameters() throws Exception {
+		String invocationURL = _getInvocationURL(new HashMap<String, String>());
+
+		Assert.assertEquals(_JOB_URL + "/buildWithParameters", invocationURL);
+
+		Map<String, String> parameters = _setInvocationURL(invocationURL);
+
+		Assert.assertTrue(parameters.isEmpty());
+	}
+
+	@Test
 	public void testLoadParametersFromQueryString() {
 		Map<String, String> parameters = _loadParametersFromQueryString(
 			JenkinsResultsParserUtil.combine(
@@ -159,6 +187,29 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 			ReflectionTestUtil.getFieldValue(baseBuild, "_jobName"));
 	}
 
+	private String _getInvocationURL(Map<String, String> parameters) {
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		Mockito.when(
+			baseBuild.getJobURL()
+		).thenReturn(
+			_JOB_URL
+		);
+
+		Mockito.when(
+			baseBuild.getParameters()
+		).thenReturn(
+			parameters
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).getInvocationURL();
+
+		return baseBuild.getInvocationURL();
+	}
+
 	private Map<String, String> _loadParametersFromQueryString(
 		String queryString) {
 
@@ -195,6 +246,48 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 		).getDisplayName();
 
 		return baseDownstreamBuild;
+	}
+
+	private Map<String, String> _newParameters(String... namesAndValues) {
+		Map<String, String> parameters = new HashMap<>();
+
+		for (int i = 0; i < namesAndValues.length; i = i + 2) {
+			parameters.put(namesAndValues[i], namesAndValues[i + 1]);
+		}
+
+		return parameters;
+	}
+
+	private Map<String, String> _setInvocationURL(String invocationURL)
+		throws Exception {
+
+		BaseBuild baseBuild = Mockito.mock(BaseBuild.class);
+
+		ReflectionTestUtil.setFieldValue(
+			baseBuild, "_parameters", new HashMap<String, String>());
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).loadParametersFromQueryString(
+			Mockito.anyString()
+		);
+
+		Mockito.doCallRealMethod(
+		).when(
+			baseBuild
+		).setJobName(
+			Mockito.anyString()
+		);
+
+		Method method = BaseBuild.class.getDeclaredMethod(
+			"_setInvocationURL", String.class);
+
+		method.setAccessible(true);
+
+		method.invoke(baseBuild, invocationURL);
+
+		return ReflectionTestUtil.getFieldValue(baseBuild, "_parameters");
 	}
 
 	private void _testSaveBuildURLInBuildDatabase(
@@ -239,5 +332,9 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 			Mockito.verifyNoInteractions(buildDatabase);
 		}
 	}
+
+	private static final String _JOB_URL = JenkinsResultsParserUtil.combine(
+		"https://test-1.liferay.com/job/",
+		"test-portal-acceptance-pullrequest(master)");
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/BaseBuildTest.java
@@ -72,7 +72,7 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
 	public void testGetInvocationURL() throws Exception {
-		Map<String, String> parameters = _newParameters(
+		Map<String, String> parameters = newParameters(
 			"PORTAL BUILD NOTES", "encoded name", "PORTAL_BATCH_TEST_SELECTOR",
 			"PortalSmoke#Smoke", "PORTAL_BUILD_NOTES", "100% pass",
 			"PORTAL_QUERY", "a=b", "PORTAL_UPSTREAM", "a+b",
@@ -246,16 +246,6 @@ public class BaseBuildTest extends com.liferay.jenkins.results.parser.Test {
 		).getDisplayName();
 
 		return baseDownstreamBuild;
-	}
-
-	private Map<String, String> _newParameters(String... namesAndValues) {
-		Map<String, String> parameters = new HashMap<>();
-
-		for (int i = 0; i < namesAndValues.length; i = i + 2) {
-			parameters.put(namesAndValues[i], namesAndValues[i + 1]);
-		}
-
-		return parameters;
 	}
 
 	private Map<String, String> _setInvocationURL(String invocationURL)

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -69,10 +69,6 @@ public class JenkinsResultsParserUtilTest
 		testEquals(
 			"0%201%202", JenkinsResultsParserUtil.encodeLegacyURLPart("0 1 2"));
 
-		// A percent sign and a plus sign survive unencoded. That is wrong in
-		// principle and is why this spelling is confined to callers matching a
-		// name that was already written
-
 		testEquals(
 			"100%%20pass",
 			JenkinsResultsParserUtil.encodeLegacyURLPart("100% pass"));

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtilTest.java
@@ -51,6 +51,35 @@ public class JenkinsResultsParserUtilTest
 	}
 
 	@Test
+	public void testEncodeLegacyURLPart() {
+		testEquals(
+			"ABC%28123",
+			JenkinsResultsParserUtil.encodeLegacyURLPart("ABC(123"));
+		testEquals(
+			"ABC%29123",
+			JenkinsResultsParserUtil.encodeLegacyURLPart("ABC)123"));
+		testEquals(
+			"ABC%5B123",
+			JenkinsResultsParserUtil.encodeLegacyURLPart("ABC[123"));
+		testEquals(
+			"ABC%5D123",
+			JenkinsResultsParserUtil.encodeLegacyURLPart("ABC]123"));
+		testEquals(
+			"!master", JenkinsResultsParserUtil.encodeLegacyURLPart("!master"));
+		testEquals(
+			"0%201%202", JenkinsResultsParserUtil.encodeLegacyURLPart("0 1 2"));
+
+		// A percent sign and a plus sign survive unencoded. That is wrong in
+		// principle and is why this spelling is confined to callers matching a
+		// name that was already written
+
+		testEquals(
+			"100%%20pass",
+			JenkinsResultsParserUtil.encodeLegacyURLPart("100% pass"));
+		testEquals("a+b", JenkinsResultsParserUtil.encodeLegacyURLPart("a+b"));
+	}
+
+	@Test
 	public void testEncodeURLParameterPart() {
 		testEquals(
 			"100%25%20pass",
@@ -126,22 +155,6 @@ public class JenkinsResultsParserUtilTest
 		testEquals("ABC&#125;123", JenkinsResultsParserUtil.fixJSON("ABC}123"));
 		testEquals(
 			"ABC<br />123", JenkinsResultsParserUtil.fixJSON("ABC\n123"));
-	}
-
-	@Test
-	public void testFixURL() {
-		testEquals("ABC%28123", _fixURLMultipleTimes("ABC(123"));
-		testEquals("ABC%29123", _fixURLMultipleTimes("ABC)123"));
-		testEquals("ABC%5B123", _fixURLMultipleTimes("ABC[123"));
-		testEquals("ABC%5D123", _fixURLMultipleTimes("ABC]123"));
-		testEquals("!master", _fixURLMultipleTimes("!master"));
-		testEquals("0%201%202", _fixURLMultipleTimes("0 1 2"));
-		testEquals(
-			"https://test-1-1.liferay.com/job(master)?" +
-				"AXIS_VARIABLE=0%201&label_exp=!master&job=test%287.2.x%29",
-			_fixURLMultipleTimes(
-				"https://test-1-1.liferay.com/job(master)?" +
-					"AXIS_VARIABLE=0 1&label_exp=!master&job=test(7.2.x)"));
 	}
 
 	@Test
@@ -706,12 +719,6 @@ public class JenkinsResultsParserUtilTest
 
 	private ServerSocket _createServerSocket() throws Exception {
 		return new ServerSocket(0, 1, InetAddress.getByName("localhost"));
-	}
-
-	private String _fixURLMultipleTimes(String urlString) {
-		return JenkinsResultsParserUtil.fixURL(
-			JenkinsResultsParserUtil.fixURL(
-				JenkinsResultsParserUtil.fixURL(urlString)));
 	}
 
 	private Properties _getBuildAwsProperties() {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/Test.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -173,6 +174,16 @@ public class Test {
 		UrlReader.setInstance(urlReader);
 
 		return urlReader;
+	}
+
+	protected Map<String, String> newParameters(String... namesAndValues) {
+		Map<String, String> parameters = new LinkedHashMap<>();
+
+		for (int i = 0; i < namesAndValues.length; i = i + 2) {
+			parameters.put(namesAndValues[i], namesAndValues[i + 1]);
+		}
+
+		return parameters;
 	}
 
 	protected String read(File file) throws IOException {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
@@ -1,0 +1,259 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * @author Calum Ragan
+ */
+public class URLBuilderUtilTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testAppendParameter() {
+		testEquals(
+			"http://test-1-1/job/x?tree=result",
+			URLBuilderUtil.appendParameter(
+				"http://test-1-1/job/x", "tree", "result"));
+	}
+
+	@Test
+	public void testAppendParameterWithExistingQueryString() {
+		testEquals(
+			"http://test-1-1/job/x?a=1&b=2",
+			URLBuilderUtil.appendParameter(
+				"http://test-1-1/job/x?a=1", "b", "2"));
+	}
+
+	@Test
+	public void testAppendParameterWithFragment() {
+		testEquals(
+			"http://test-1-1/job/x?a=1&b=2#summary",
+			URLBuilderUtil.appendParameter(
+				"http://test-1-1/job/x?a=1#summary", "b", "2"));
+	}
+
+	@Test
+	public void testBuildFormContent() {
+		testEquals(
+			"client_id=a%26b&grant_type=client_credentials",
+			URLBuilderUtil.buildFormContent(
+				_newParameters(
+					"grant_type", "client_credentials", "client_id", "a&b")));
+	}
+
+	@Test
+	public void testBuildFormContentWithoutParameters() {
+		testEquals("", URLBuilderUtil.buildFormContent(Collections.emptyMap()));
+	}
+
+	@Test
+	public void testBuildURL() {
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"http://test-1-1/job/x/buildWithParameters?",
+				"JOB_VARIANT=functional&PARENT_BUILD_URL=",
+				"http%3A%2F%2Ftest-1-1%2Fjob%2Fy%2F1%2F"),
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x/buildWithParameters",
+				_newParameters(
+					"PARENT_BUILD_URL", "http://test-1-1/job/y/1/",
+					"JOB_VARIANT", "functional")));
+	}
+
+	@Test
+	public void testBuildURLPreservesPath() {
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"http://test-1-1/job/test-portal-acceptance-pullrequest",
+				"(master)/buildWithParameters?a=1"),
+			URLBuilderUtil.buildURL(
+				JenkinsResultsParserUtil.combine(
+					"http://test-1-1/job/test-portal-acceptance-pullrequest",
+					"(master)/buildWithParameters"),
+				"a", "1"));
+	}
+
+	@Test
+	public void testBuildURLSortsParameters() {
+		testEquals(
+			"http://test-1-1/job/x?alpha=1&beta=2&gamma=3",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x",
+				_newParameters("gamma", "3", "beta", "2", "alpha", "1")));
+	}
+
+	@Test
+	public void testBuildURLWithEmptyValue() {
+		testEquals(
+			"http://test-1-1/job/x?AXIS_VARIABLE=",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x", "AXIS_VARIABLE", ""));
+	}
+
+	@Test
+	public void testBuildURLWithNullValue() {
+		testEquals(
+			"http://test-1-1/job/x/api/json?pretty",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x/api/json", "pretty", null));
+	}
+
+	@Test
+	public void testBuildURLWithoutParameters() {
+		testEquals(
+			"http://test-1-1/job/x/buildWithParameters",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x/buildWithParameters",
+				Collections.emptyMap()));
+	}
+
+	@Test
+	public void testBuildURLWithReservedCharacters() {
+		testEquals(
+			"http://test-1-1/job/x?V=PortalSmoke%23Smoke",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x", "V", "PortalSmoke#Smoke"));
+		testEquals(
+			"http://test-1-1/job/x?V=AWS+%26+CI",
+			URLBuilderUtil.buildURL("http://test-1-1/job/x", "V", "AWS & CI"));
+		testEquals(
+			"http://test-1-1/job/x?V=100%25+pass",
+			URLBuilderUtil.buildURL("http://test-1-1/job/x", "V", "100% pass"));
+		testEquals(
+			"http://test-1-1/job/x?V=a%3Db",
+			URLBuilderUtil.buildURL("http://test-1-1/job/x", "V", "a=b"));
+		testEquals(
+			"http://test-1-1/job/x?V=a%2Bb",
+			URLBuilderUtil.buildURL("http://test-1-1/job/x", "V", "a+b"));
+		testEquals(
+			"http://test-1-1/job/x?V=a+b",
+			URLBuilderUtil.buildURL("http://test-1-1/job/x", "V", "a b"));
+	}
+
+	@Test
+	public void testGetParameters() {
+		Map<String, String> parameters = URLBuilderUtil.getParameters(
+			JenkinsResultsParserUtil.combine(
+				"http://test-1-1/job/x/buildWithParameters?",
+				"JOB_VARIANT=functional&PARENT_BUILD_URL=",
+				"http%3A%2F%2Ftest-1-1%2Fjob%2Fy%2F1%2F"));
+
+		testEquals(2, parameters.size());
+		testEquals("functional", parameters.get("JOB_VARIANT"));
+		testEquals(
+			"http://test-1-1/job/y/1/", parameters.get("PARENT_BUILD_URL"));
+	}
+
+	@Test
+	public void testGetParametersWithInvalidEscape() {
+		Map<String, String> parameters = URLBuilderUtil.getParameters(
+			"http://test-1-1/job/x?PORTAL_BUILD_NOTES=100% pass");
+
+		testEquals(1, parameters.size());
+		testEquals("100% pass", parameters.get("PORTAL_BUILD_NOTES"));
+	}
+
+	@Test
+	public void testGetParametersWithoutQueryString() {
+		Map<String, String> parameters = URLBuilderUtil.getParameters(
+			"http://test-1-1/job/x/1/");
+
+		testEquals(0, parameters.size());
+	}
+
+	@Test
+	public void testNormalizeURLIsIdempotent() {
+		String normalizedURL = URLBuilderUtil.normalizeURL(
+			"http://test-1-1/job/x?tree=actions[parameters[name,value]]");
+
+		testEquals(normalizedURL, URLBuilderUtil.normalizeURL(normalizedURL));
+	}
+
+	@Test
+	public void testNormalizeURLPreservesFragment() {
+		testEquals(
+			"http://test-1-1/job/x?a=1#summary",
+			URLBuilderUtil.normalizeURL("http://test-1-1/job/x?a=1#summary"));
+	}
+
+	@Test
+	public void testNormalizeURLPreservesLegalURL() {
+		String url = JenkinsResultsParserUtil.combine(
+			"http://test-1-1/job/test-portal-acceptance-pullrequest(master)/",
+			"buildWithParameters?V=a%2Bb&W=AWS%20%26%20CI");
+
+		testSame(url, URLBuilderUtil.normalizeURL(url));
+	}
+
+	@Test
+	public void testNormalizeURLWithBarePercent() {
+		testEquals(
+			"http://test-1-1/job/x?V=100%25%20pass",
+			URLBuilderUtil.normalizeURL("http://test-1-1/job/x?V=100% pass"));
+	}
+
+	@Test
+	public void testNormalizeURLWithIllegalPathCharacters() {
+		testEquals(
+			"http://test-1-1/job/a%20b/1/",
+			URLBuilderUtil.normalizeURL("http://test-1-1/job/a b/1/"));
+		testEquals(
+			"http://test-1-1/job/x?tree=result%5B0%5D",
+			URLBuilderUtil.normalizeURL(
+				"http://test-1-1/job/x?tree=result[0]"));
+	}
+
+	@Test
+	public void testParseQueryStringWithEmptyAndValuelessParameters() {
+		Map<String, String> parameters = URLBuilderUtil.parseQueryString(
+			"AXIS_VARIABLE=&pretty");
+
+		testEquals(2, parameters.size());
+		testEquals("", parameters.get("AXIS_VARIABLE"));
+		testEquals(null, parameters.get("pretty"));
+	}
+
+	@Test
+	public void testParseQueryStringWithRepeatedName() {
+		Map<String, String> parameters = URLBuilderUtil.parseQueryString(
+			"V=1&V=2");
+
+		testEquals(1, parameters.size());
+		testEquals("1", parameters.get("V"));
+	}
+
+	@Test
+	public void testParseQueryStringWithReservedCharacters() {
+		Map<String, String> parameters = URLBuilderUtil.parseQueryString(
+			JenkinsResultsParserUtil.combine(
+				"A=PortalSmoke%23Smoke&B=AWS%20%26%20CI&C=a%3Db&D=a%2Bb&",
+				"E=a+b"));
+
+		testEquals(5, parameters.size());
+		testEquals("PortalSmoke#Smoke", parameters.get("A"));
+		testEquals("AWS & CI", parameters.get("B"));
+		testEquals("a=b", parameters.get("C"));
+		testEquals("a+b", parameters.get("D"));
+		testEquals("a b", parameters.get("E"));
+	}
+
+	private Map<String, String> _newParameters(String... namesAndValues) {
+		Map<String, String> parameters = new LinkedHashMap<>();
+
+		for (int i = 0; i < namesAndValues.length; i = i + 2) {
+			parameters.put(namesAndValues[i], namesAndValues[i + 1]);
+		}
+
+		return parameters;
+	}
+
+}

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
@@ -5,8 +5,9 @@
 
 package com.liferay.jenkins.results.parser;
 
+import java.net.URL;
+
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -18,35 +19,11 @@ public class URLBuilderUtilTest
 	extends com.liferay.jenkins.results.parser.Test {
 
 	@Test
-	public void testAppendParameter() {
-		testEquals(
-			"http://test-1-1/job/x?tree=result",
-			URLBuilderUtil.appendParameter(
-				"http://test-1-1/job/x", "tree", "result"));
-	}
-
-	@Test
-	public void testAppendParameterWithExistingQueryString() {
-		testEquals(
-			"http://test-1-1/job/x?a=1&b=2",
-			URLBuilderUtil.appendParameter(
-				"http://test-1-1/job/x?a=1", "b", "2"));
-	}
-
-	@Test
-	public void testAppendParameterWithFragment() {
-		testEquals(
-			"http://test-1-1/job/x?a=1&b=2#summary",
-			URLBuilderUtil.appendParameter(
-				"http://test-1-1/job/x?a=1#summary", "b", "2"));
-	}
-
-	@Test
 	public void testBuildFormContent() {
 		testEquals(
 			"client_id=a%26b&grant_type=client_credentials",
 			URLBuilderUtil.buildFormContent(
-				_newParameters(
+				newParameters(
 					"grant_type", "client_credentials", "client_id", "a&b")));
 	}
 
@@ -58,10 +35,9 @@ public class URLBuilderUtilTest
 	@Test
 	public void testBuildFormContentWithReservedCharacters() {
 		testEquals(
-			JenkinsResultsParserUtil.combine(
-				"A=a%23b&B=a%26b&C=100%25+pass&D=a%3Db&E=a%2Bb&F=a+b"),
+			"A=a%23b&B=a%26b&C=100%25+pass&D=a%3Db&E=a%2Bb&F=a+b",
 			URLBuilderUtil.buildFormContent(
-				_newParameters(
+				newParameters(
 					"A", "a#b", "B", "a&b", "C", "100% pass", "D", "a=b", "E",
 					"a+b", "F", "a b")));
 	}
@@ -75,7 +51,7 @@ public class URLBuilderUtilTest
 				"http%3A%2F%2Ftest-1-1%2Fjob%2Fy%2F1%2F"),
 			URLBuilderUtil.buildURL(
 				"http://test-1-1/job/x/buildWithParameters",
-				_newParameters(
+				newParameters(
 					"PARENT_BUILD_URL", "http://test-1-1/job/y/1/",
 					"JOB_VARIANT", "functional")));
 	}
@@ -94,17 +70,24 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
-	public void testBuildURLRoundTripsReservedCharacters() {
-		Map<String, String> parameters = _newParameters(
+	public void testBuildURLRepairsIllegalBaseURL() {
+		testEquals(
+			"http://test-1-1/job/a%20b/api/json?tree=result",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/a b/api/json", "tree", "result"));
+	}
+
+	@Test
+	public void testBuildURLRoundTripsReservedCharacters() throws Exception {
+		Map<String, String> parameters = newParameters(
 			"A", "a#b", "B", "a&b", "C", "100% pass", "D", "a=b", "E", "a+b",
 			"F", "a b", "G a", "name with a space");
 
-		Map<String, String> roundTrippedParameters =
-			URLBuilderUtil.getParameters(
-				URLBuilderUtil.buildURL(
-					"http://test-1-1/job/x/buildWithParameters", parameters));
+		URL url = new URL(
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x/buildWithParameters", parameters));
 
-		testEquals(parameters, roundTrippedParameters);
+		testEquals(parameters, URLBuilderUtil.parseQueryString(url.getQuery()));
 	}
 
 	@Test
@@ -113,7 +96,7 @@ public class URLBuilderUtilTest
 			"http://test-1-1/job/x?alpha=1&beta=2&gamma=3",
 			URLBuilderUtil.buildURL(
 				"http://test-1-1/job/x",
-				_newParameters("gamma", "3", "beta", "2", "alpha", "1")));
+				newParameters("gamma", "3", "beta", "2", "alpha", "1")));
 	}
 
 	@Test
@@ -122,6 +105,21 @@ public class URLBuilderUtilTest
 			"http://test-1-1/job/x?AXIS_VARIABLE=",
 			URLBuilderUtil.buildURL(
 				"http://test-1-1/job/x", "AXIS_VARIABLE", ""));
+	}
+
+	@Test
+	public void testBuildURLWithExistingQueryString() {
+		testEquals(
+			"http://test-1-1/job/x?a=1&b=2",
+			URLBuilderUtil.buildURL("http://test-1-1/job/x?a=1", "b", "2"));
+	}
+
+	@Test
+	public void testBuildURLWithFragment() {
+		testEquals(
+			"http://test-1-1/job/x?a=1&b=2#summary",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x?a=1#summary", "b", "2"));
 	}
 
 	@Test
@@ -165,42 +163,20 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
-	public void testGetParameters() {
-		Map<String, String> parameters = URLBuilderUtil.getParameters(
-			JenkinsResultsParserUtil.combine(
-				"http://test-1-1/job/x/buildWithParameters?",
-				"JOB_VARIANT=functional&PARENT_BUILD_URL=",
-				"http%3A%2F%2Ftest-1-1%2Fjob%2Fy%2F1%2F"));
-
-		testEquals(2, parameters.size());
-		testEquals("functional", parameters.get("JOB_VARIANT"));
-		testEquals(
-			"http://test-1-1/job/y/1/", parameters.get("PARENT_BUILD_URL"));
-	}
-
-	@Test
-	public void testGetParametersWithInvalidEscape() {
-		Map<String, String> parameters = URLBuilderUtil.getParameters(
-			"http://test-1-1/job/x?PORTAL_BUILD_NOTES=100% pass");
-
-		testEquals(1, parameters.size());
-		testEquals("100% pass", parameters.get("PORTAL_BUILD_NOTES"));
-	}
-
-	@Test
-	public void testGetParametersWithoutQueryString() {
-		Map<String, String> parameters = URLBuilderUtil.getParameters(
-			"http://test-1-1/job/x/1/");
-
-		testEquals(0, parameters.size());
-	}
-
-	@Test
 	public void testNormalizeURLIsIdempotent() {
 		String normalizedURL = URLBuilderUtil.normalizeURL(
 			"http://test-1-1/job/x?tree=actions[parameters[name,value]]");
 
 		testEquals(normalizedURL, URLBuilderUtil.normalizeURL(normalizedURL));
+	}
+
+	@Test
+	public void testNormalizeURLPreservesEncodedParameters() {
+		String url = JenkinsResultsParserUtil.combine(
+			"http://test-1-1/job/x/buildWithParameters?",
+			"A=a%23b&B=a%26b&C=100%25%20pass&D=a%3Db&E=a%2Bb&F=a%20b");
+
+		testSame(url, URLBuilderUtil.normalizeURL(url));
 	}
 
 	@Test
@@ -227,19 +203,6 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
-	public void testNormalizeURLWithEncodedParameters() {
-		String[] values = {"a#b", "a&b", "100% pass", "a=b", "a+b", "a b"};
-
-		for (String value : values) {
-			String url = JenkinsResultsParserUtil.combine(
-				"http://test-1-1/job/x/buildWithParameters?V=",
-				JenkinsResultsParserUtil.encodeURLParameterPart(value));
-
-			testEquals(url, URLBuilderUtil.normalizeURL(url));
-		}
-	}
-
-	@Test
 	public void testNormalizeURLWithIllegalPathCharacters() {
 		testEquals(
 			"http://test-1-1/job/a%20b/1/",
@@ -258,6 +221,42 @@ public class URLBuilderUtilTest
 		testEquals(2, parameters.size());
 		testEquals("", parameters.get("AXIS_VARIABLE"));
 		testEquals(null, parameters.get("pretty"));
+	}
+
+	@Test
+	public void testParseQueryStringWithInvalidEscape() {
+		Map<String, String> parameters = URLBuilderUtil.parseQueryString(
+			"PORTAL_BUILD_NOTES=100% pass");
+
+		testEquals(1, parameters.size());
+		testEquals("100% pass", parameters.get("PORTAL_BUILD_NOTES"));
+	}
+
+	@Test
+	public void testParseQueryStringWithNestedURL() {
+		Map<String, String> parameters = URLBuilderUtil.parseQueryString(
+			JenkinsResultsParserUtil.combine(
+				"JOB_VARIANT=functional&PARENT_BUILD_URL=",
+				"http%3A%2F%2Ftest-1-1%2Fjob%2Fy%2F1%2F"));
+
+		testEquals(2, parameters.size());
+		testEquals("functional", parameters.get("JOB_VARIANT"));
+		testEquals(
+			"http://test-1-1/job/y/1/", parameters.get("PARENT_BUILD_URL"));
+	}
+
+	@Test
+	public void testParseQueryStringWithoutQueryString() {
+		testEquals(
+			0,
+			URLBuilderUtil.parseQueryString(
+				null
+			).size());
+		testEquals(
+			0,
+			URLBuilderUtil.parseQueryString(
+				""
+			).size());
 	}
 
 	@Test
@@ -283,16 +282,6 @@ public class URLBuilderUtilTest
 		testEquals("a+b", parameters.get("D"));
 		testEquals("a b", parameters.get("E"));
 		testEquals("100% pass", parameters.get("F"));
-	}
-
-	private Map<String, String> _newParameters(String... namesAndValues) {
-		Map<String, String> parameters = new LinkedHashMap<>();
-
-		for (int i = 0; i < namesAndValues.length; i = i + 2) {
-			parameters.put(namesAndValues[i], namesAndValues[i + 1]);
-		}
-
-		return parameters;
 	}
 
 }

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
@@ -202,6 +202,19 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
+	public void testNormalizeURLWithEncodedParameters() {
+		String[] values = {"a#b", "a&b", "100% pass", "a=b", "a+b", "a b"};
+
+		for (String value : values) {
+			String url = JenkinsResultsParserUtil.combine(
+				"http://test-1-1/job/x/buildWithParameters?V=",
+				JenkinsResultsParserUtil.encodeURLParameterPart(value));
+
+			testEquals(url, URLBuilderUtil.normalizeURL(url));
+		}
+	}
+
+	@Test
 	public void testNormalizeURLWithIllegalPathCharacters() {
 		testEquals(
 			"http://test-1-1/job/a%20b/1/",

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
@@ -56,6 +56,17 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
+	public void testBuildFormContentWithReservedCharacters() {
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"A=a%23b&B=a%26b&C=100%25+pass&D=a%3Db&E=a%2Bb&F=a+b"),
+			URLBuilderUtil.buildFormContent(
+				_newParameters(
+					"A", "a#b", "B", "a&b", "C", "100% pass", "D", "a=b", "E",
+					"a+b", "F", "a b")));
+	}
+
+	@Test
 	public void testBuildURL() {
 		testEquals(
 			JenkinsResultsParserUtil.combine(
@@ -80,6 +91,20 @@ public class URLBuilderUtilTest
 					"http://test-1-1/job/test-portal-acceptance-pullrequest",
 					"(master)/buildWithParameters"),
 				"a", "1"));
+	}
+
+	@Test
+	public void testBuildURLRoundTripsReservedCharacters() {
+		Map<String, String> parameters = _newParameters(
+			"A", "a#b", "B", "a&b", "C", "100% pass", "D", "a=b", "E", "a+b",
+			"F", "a b", "G a", "name with a space");
+
+		Map<String, String> roundTrippedParameters =
+			URLBuilderUtil.getParameters(
+				URLBuilderUtil.buildURL(
+					"http://test-1-1/job/x/buildWithParameters", parameters));
+
+		testEquals(parameters, roundTrippedParameters);
 	}
 
 	@Test
@@ -249,14 +274,15 @@ public class URLBuilderUtilTest
 		Map<String, String> parameters = URLBuilderUtil.parseQueryString(
 			JenkinsResultsParserUtil.combine(
 				"A=PortalSmoke%23Smoke&B=AWS%20%26%20CI&C=a%3Db&D=a%2Bb&",
-				"E=a+b"));
+				"E=a+b&F=100%25%20pass"));
 
-		testEquals(5, parameters.size());
+		testEquals(6, parameters.size());
 		testEquals("PortalSmoke#Smoke", parameters.get("A"));
 		testEquals("AWS & CI", parameters.get("B"));
 		testEquals("a=b", parameters.get("C"));
 		testEquals("a+b", parameters.get("D"));
 		testEquals("a b", parameters.get("E"));
+		testEquals("100% pass", parameters.get("F"));
 	}
 
 	private Map<String, String> _newParameters(String... namesAndValues) {

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLBuilderUtilTest.java
@@ -57,49 +57,6 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
-	public void testBuildURLPreservesPath() {
-		testEquals(
-			JenkinsResultsParserUtil.combine(
-				"http://test-1-1/job/test-portal-acceptance-pullrequest",
-				"(master)/buildWithParameters?a=1"),
-			URLBuilderUtil.buildURL(
-				JenkinsResultsParserUtil.combine(
-					"http://test-1-1/job/test-portal-acceptance-pullrequest",
-					"(master)/buildWithParameters"),
-				"a", "1"));
-	}
-
-	@Test
-	public void testBuildURLRepairsIllegalBaseURL() {
-		testEquals(
-			"http://test-1-1/job/a%20b/api/json?tree=result",
-			URLBuilderUtil.buildURL(
-				"http://test-1-1/job/a b/api/json", "tree", "result"));
-	}
-
-	@Test
-	public void testBuildURLRoundTripsReservedCharacters() throws Exception {
-		Map<String, String> parameters = newParameters(
-			"A", "a#b", "B", "a&b", "C", "100% pass", "D", "a=b", "E", "a+b",
-			"F", "a b", "G a", "name with a space");
-
-		URL url = new URL(
-			URLBuilderUtil.buildURL(
-				"http://test-1-1/job/x/buildWithParameters", parameters));
-
-		testEquals(parameters, URLBuilderUtil.parseQueryString(url.getQuery()));
-	}
-
-	@Test
-	public void testBuildURLSortsParameters() {
-		testEquals(
-			"http://test-1-1/job/x?alpha=1&beta=2&gamma=3",
-			URLBuilderUtil.buildURL(
-				"http://test-1-1/job/x",
-				newParameters("gamma", "3", "beta", "2", "alpha", "1")));
-	}
-
-	@Test
 	public void testBuildURLWithEmptyValue() {
 		testEquals(
 			"http://test-1-1/job/x?AXIS_VARIABLE=",
@@ -123,6 +80,14 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
+	public void testBuildURLWithIllegalBaseURL() {
+		testEquals(
+			"http://test-1-1/job/a%20b/api/json?tree=result",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/a b/api/json", "tree", "result"));
+	}
+
+	@Test
 	public void testBuildURLWithNullValue() {
 		testEquals(
 			"http://test-1-1/job/x/api/json?pretty",
@@ -137,6 +102,19 @@ public class URLBuilderUtilTest
 			URLBuilderUtil.buildURL(
 				"http://test-1-1/job/x/buildWithParameters",
 				Collections.emptyMap()));
+	}
+
+	@Test
+	public void testBuildURLWithParenthesesInPath() {
+		testEquals(
+			JenkinsResultsParserUtil.combine(
+				"http://test-1-1/job/test-portal-acceptance-pullrequest",
+				"(master)/buildWithParameters?a=1"),
+			URLBuilderUtil.buildURL(
+				JenkinsResultsParserUtil.combine(
+					"http://test-1-1/job/test-portal-acceptance-pullrequest",
+					"(master)/buildWithParameters"),
+				"a", "1"));
 	}
 
 	@Test
@@ -163,15 +141,23 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
-	public void testNormalizeURLIsIdempotent() {
-		String normalizedURL = URLBuilderUtil.normalizeURL(
-			"http://test-1-1/job/x?tree=actions[parameters[name,value]]");
-
-		testEquals(normalizedURL, URLBuilderUtil.normalizeURL(normalizedURL));
+	public void testBuildURLWithUnsortedParameters() {
+		testEquals(
+			"http://test-1-1/job/x?alpha=1&beta=2&gamma=3",
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x",
+				newParameters("gamma", "3", "beta", "2", "alpha", "1")));
 	}
 
 	@Test
-	public void testNormalizeURLPreservesEncodedParameters() {
+	public void testNormalizeURLWithBarePercent() {
+		testEquals(
+			"http://test-1-1/job/x?V=100%25%20pass",
+			URLBuilderUtil.normalizeURL("http://test-1-1/job/x?V=100% pass"));
+	}
+
+	@Test
+	public void testNormalizeURLWithEncodedParameters() {
 		String url = JenkinsResultsParserUtil.combine(
 			"http://test-1-1/job/x/buildWithParameters?",
 			"A=a%23b&B=a%26b&C=100%25%20pass&D=a%3Db&E=a%2Bb&F=a%20b");
@@ -180,26 +166,10 @@ public class URLBuilderUtilTest
 	}
 
 	@Test
-	public void testNormalizeURLPreservesFragment() {
+	public void testNormalizeURLWithFragment() {
 		testEquals(
 			"http://test-1-1/job/x?a=1#summary",
 			URLBuilderUtil.normalizeURL("http://test-1-1/job/x?a=1#summary"));
-	}
-
-	@Test
-	public void testNormalizeURLPreservesLegalURL() {
-		String url = JenkinsResultsParserUtil.combine(
-			"http://test-1-1/job/test-portal-acceptance-pullrequest(master)/",
-			"buildWithParameters?V=a%2Bb&W=AWS%20%26%20CI");
-
-		testSame(url, URLBuilderUtil.normalizeURL(url));
-	}
-
-	@Test
-	public void testNormalizeURLWithBarePercent() {
-		testEquals(
-			"http://test-1-1/job/x?V=100%25%20pass",
-			URLBuilderUtil.normalizeURL("http://test-1-1/job/x?V=100% pass"));
 	}
 
 	@Test
@@ -211,6 +181,36 @@ public class URLBuilderUtilTest
 			"http://test-1-1/job/x?tree=result%5B0%5D",
 			URLBuilderUtil.normalizeURL(
 				"http://test-1-1/job/x?tree=result[0]"));
+	}
+
+	@Test
+	public void testNormalizeURLWithLegalURL() {
+		String url = JenkinsResultsParserUtil.combine(
+			"http://test-1-1/job/test-portal-acceptance-pullrequest(master)/",
+			"buildWithParameters?V=a%2Bb&W=AWS%20%26%20CI");
+
+		testSame(url, URLBuilderUtil.normalizeURL(url));
+	}
+
+	@Test
+	public void testNormalizeURLWithNormalizedURL() {
+		String normalizedURL = URLBuilderUtil.normalizeURL(
+			"http://test-1-1/job/x?tree=actions[parameters[name,value]]");
+
+		testEquals(normalizedURL, URLBuilderUtil.normalizeURL(normalizedURL));
+	}
+
+	@Test
+	public void testParseQueryStringWithBuiltURL() throws Exception {
+		Map<String, String> parameters = newParameters(
+			"A", "a#b", "B", "a&b", "C", "100% pass", "D", "a=b", "E", "a+b",
+			"F", "a b", "G a", "name with a space");
+
+		URL url = new URL(
+			URLBuilderUtil.buildURL(
+				"http://test-1-1/job/x/buildWithParameters", parameters));
+
+		testEquals(parameters, URLBuilderUtil.parseQueryString(url.getQuery()));
 	}
 
 	@Test

--- a/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLCompareUtilTest.java
+++ b/modules/test/jenkins-results-parser/src/test/java/com/liferay/jenkins/results/parser/URLCompareUtilTest.java
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.jenkins.results.parser;
+
+import java.net.URL;
+
+import org.junit.Test;
+
+/**
+ * @author Calum Ragan
+ */
+public class URLCompareUtilTest
+	extends com.liferay.jenkins.results.parser.Test {
+
+	@Test
+	public void testMatches() throws Exception {
+		testEquals(
+			true,
+			URLCompareUtil.matches(
+				new URL("http://test-1-1/job/x/1/"),
+				new URL("http://test-1-1/job/x/1")));
+		testEquals(
+			false,
+			URLCompareUtil.matches(
+				new URL("http://test-1-1/job/x/1/"),
+				new URL("http://test-1-1/job/y/1/")));
+	}
+
+	@Test
+	public void testMatchesWithEmptyParameterValue() throws Exception {
+		testEquals(
+			true,
+			URLCompareUtil.matches(
+				new URL("http://test-1-1/job/x?AXIS_VARIABLE=&JOB=y"),
+				new URL("http://test-1-1/job/x?AXIS_VARIABLE=&JOB=y")));
+		testEquals(
+			false,
+			URLCompareUtil.matches(
+				new URL("http://test-1-1/job/x?AXIS_VARIABLE=&JOB=y"),
+				new URL("http://test-1-1/job/x?AXIS_VARIABLE=1&JOB=y")));
+	}
+
+	@Test
+	public void testMatchesWithEquivalentParameterSpellings() throws Exception {
+		testEquals(
+			true,
+			URLCompareUtil.matches(
+				new URL("http://test-1-1/job/x?V=AWS%20%26%20CI"),
+				new URL("http://test-1-1/job/x?V=AWS+%26+CI")));
+	}
+
+	@Test
+	public void testMatchesWithReorderedParameters() throws Exception {
+		testEquals(
+			true,
+			URLCompareUtil.matches(
+				new URL("http://test-1-1/job/x?A=1&B=2"),
+				new URL("http://test-1-1/job/x?B=2&A=1")));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LRCI-7983

CI Infrastructure assembles URLs by concatenating raw strings and takes them apart again by splitting on `&` and `=`. Once a value is concatenated in, its characters are indistinguishable from the query string's own syntax, so an `&`, `#`, `=`, or `%` in any value corrupts the URL. This branch moves construction and decomposition behind a single class so that a value is encoded exactly once, when the URL is assembled, and is held decoded everywhere else.

## Base

Based on `LRCI-7942`, not `master`. That branch added `encodeURLParameterPart` and `decodeURLParameterPart`, which this work builds on and then subsumes. Reviewing against `master` instead adds its two commits to the diff.

The matching `liferay-jenkins-ee` branch is `CalumR23/liferay-jenkins-ee@LRCI-7983`. The two are coupled and must land together — `fixURL` is deleted here and `liferay-jenkins-ee` held its last caller.

## The finding that made this necessary

`fixURL` was applied to every outbound URL in `UrlReader`, and it was silently undoing the encoding `LRCI-7942` had just added. Measured against the real implementation:

| Value | `encodeURLParameterPart` produced | What went on the wire |
| --- | --- | --- |
| `a+b` | `a%2Bb` | `a+b`, which Jenkins decodes as `a b` |
| `PORTAL BUILD NOTES=x` (name) | `PORTAL%20BUILD%20NOTES=x` | `20NOTES=x` — name corrupted |
| `http://h/a?x=1#frag` | — | `http://h/a?x=1` — fragment dropped |

The name corruption came from `_urlQueryStringPattern`, `\&??(\w++)=([^\&]*)`, which matches only the final word-character run before the `=`. Any construction-site change made before the boundary was fixed would have been cosmetic, so `Stop the HTTP boundary from re-encoding legal URLs` is the hinge commit — everything before it is setup and everything after it depends on it.

## Design

`URLBuilderUtil` is a new class rather than more methods on `JenkinsResultsParserUtil`, for one reason worth stating: it turns the concern about scattering `URIBuilder` across the module into a checkable invariant.

```
grep -rl "org.apache.http" modules/test/jenkins-results-parser/src/main
```

prints exactly one file. Because no other file can name `URIBuilder`, none can hold one as a field, which is what keeps a mutable builder from being shared across the threads `ParallelExecutor` runs.

Five methods, contracts chosen while the API is new:

- Parameters emit in ascending name order, so the same map always produces the same URL. The previous `HashMap` iteration in `getInvocationURL` produced a different URL per JVM.
- An empty or null map returns the base URL unchanged, with no trailing `?`. This also fixes the empty-parameter case, which `URIBuilder` does not handle on its own.
- A repeated name keeps the first value and reports the dropped one. The previous behaviour was silently last-wins.
- `normalizeURL` returns a URL untouched when it already parses as a legal URI reference, and otherwise encodes only the octets that are illegal where they sit, leaving a valid triple alone so it is idempotent. It never throws — `doRead` must not start failing where it did not before.

Query strings are decomposed with `URLEncodedUtils.parse` rather than `URIBuilder.getQueryParams`. The ticket asks for the latter, but `getQueryParams` parses the whole URL strictly first and rejects a bare `%`, which would regress LRCI-7942's deliberate contract that an invalid triple is read as raw text rather than failing the build. `parse` is the same decomposition engine without the strict pre-parse.

## Deliberately not converted

- `getLocalURL` / `getRemoteURL` — the `indexOf("?")` split-and-reattach is correct by design. It preserves the query byte for byte and must accept inputs that are not legal URI references, including `file:` URLs and unresolved `${dependencies.url}` templates.
- POST bodies in `invokeJenkinsBuild`, `executeJenkinsScript`, and `_refreshToken` — these are `application/x-www-form-urlencoded` bodies, not URLs, so they use `buildFormContent`. The last one is a real fix: it concatenated both of its client fields raw, so a value holding `&`, `+`, or `=` produced a request that either carried the wrong value or silently gained an extra field.
- Four cloud-storage object keys — these append to a blob key, not a URL. Attachment lookup matches by `endsWith`, so re-spelling them would break it silently. Left with a comment.
- `BaseBuild`'s literal `?pretty` on an archive URL — that URL may be a `file:` URL or still hold an unresolved token, neither of which parses as a URI reference.

## Testing

```
cd modules/test/jenkins-results-parser
../../../gradlew test --tests '*URLBuilderUtilTest' --tests '*URLCompareUtilTest' --tests '*BaseBuildTest' --tests '*JenkinsResultsParserUtilTest'
```

77 tests, 0 failures, run with `--rerun-tasks`.

`URLBuilderUtilTest` covers the six reserved characters through build and parse, empty and null values, path preservation, fragments, repeated names, invalid triples, and `normalizeURL` idempotency. The highest-value case is `BaseBuildTest.testGetInvocationURL`, which builds an invocation URL from a parameter map carrying all six characters and feeds it straight back through `_setInvocationURL`, so producer and consumer are verified against each other in one method. Deterministic name ordering is what makes that exact-string assertion writable.

The rest of the module's suite is not green locally regardless of this change — `*RelevantRuleTest` needs a checkout directory literally named `liferay-portal`, and `PullRequestTest` and the git-working-directory tests need real repositories and tokens.
